### PR TITLE
Add pxd files for all specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,21 @@ matrix:
 install:
     - pip install tox
     - pip install cython
+    - |
+        # If we're testing pypy on Travis, make sure to get a newer version of
+        # PyPy since Travis uses 2.5.
+        #
+        # Adapted from https://github.com/travis-ci/travis-ci/issues/5027#issuecomment-170939193
+        if [ "$TOX_ENV" = "pypy" ]; then
+            export PYENV_ROOT="$HOME/.pyenv"
+            if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+                cd "$PYENV_ROOT" && git pull
+            else
+                rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+            fi
+            export PYPY_VERSION="4.0.1"
+            "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
+            export PATH="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin:$PATH"
+        fi
 script:
     - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,21 +24,5 @@ matrix:
 install:
     - pip install tox
     - pip install cython
-    - |
-        # If we're testing pypy on Travis, make sure to get a newer version of
-        # PyPy since Travis uses 2.5.
-        #
-        # Adapted from https://github.com/travis-ci/travis-ci/issues/5027#issuecomment-170939193
-        if [ "$TOX_ENV" = "pypy" ]; then
-            export PYENV_ROOT="$HOME/.pyenv"
-            if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
-                cd "$PYENV_ROOT" && git pull
-            else
-                rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
-            fi
-            export PYPY_VERSION="4.0.1"
-            "$PYENV_ROOT/bin/pyenv" install "pypy-$PYPY_VERSION"
-            export PATH="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin:$PATH"
-        fi
 script:
     - tox -e $TOX_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Releases
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Serialization and deserialization to and from binary is now almost twice as
+  fast.
 
 
 1.1.0 (2016-01-11)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ cython_modules = [
     'thriftrw.spec.field',
     'thriftrw.spec.list',
     'thriftrw.spec.map',
+    'thriftrw.spec.reference',
     'thriftrw.spec.primitive',
     'thriftrw.spec.service',
     'thriftrw.spec.set',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ cython_modules = [
     'thriftrw.protocol.core',
     'thriftrw.protocol.binary',
     'thriftrw.spec.base',
+    'thriftrw.spec.check',
     'thriftrw.spec.common',
     'thriftrw.spec.enum',
     'thriftrw.spec.exc',

--- a/thriftrw/spec/base.pxd
+++ b/thriftrw/spec/base.pxd
@@ -20,35 +20,19 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-__all__ = ['TypeReference']
+from thriftrw.wire.value cimport Value
 
 
-class TypeReference(object):
-    """A reference to another type."""
+cdef class TypeSpec(object):
 
-    __slots__ = ('name', 'lineno')
+    cpdef Value to_wire(TypeSpec self, object value)
 
-    def __init__(self, name, lineno):
-        self.name = name
-        self.lineno = lineno
+    cpdef object from_wire(TypeSpec self, Value wire_value)
 
-    def link(self, scope):
-        return scope.resolve_type_spec(self.name, self.lineno)
+    cpdef TypeSpec link(self, scope)
 
-    # It may be worth making this implement the TypeSpec interface and raise
-    # exceptions complaining about unresolved type references, since that's
-    # probably a bug.
+    cpdef object to_primitive(TypeSpec self, object value)
 
-    def __str__(self):
-        return 'TypeReference(%s, lineno=%d)' % (
-            self.name, self.lineno
-        )
+    cpdef object from_primitive(TypeSpec self, object prim_value)
 
-    __repr__ = __str__
-
-    def __eq__(self, other):
-        return (
-            other is not None and
-            self.name == other.name and
-            self.lineno == other.lineno
-        )
+    cpdef void validate(TypeSpec self, object instance) except *

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -65,7 +65,9 @@ cdef class TypeSpec(object):
         :returns thriftrw.wire.Value:
             Wire representation of the value.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            'to_wire called on unlinked type reference: %r', self
+        )
 
     cpdef object from_wire(TypeSpec self, Value wire_value):
         """Converts the given :py:class:`thriftrw.wire.Value` back into the
@@ -77,7 +79,9 @@ cdef class TypeSpec(object):
             If the type of the wire value does not have the correct Thrift
             type for this type spec.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            'from_wire called on unlinked type reference: %r', self
+        )
 
     cpdef TypeSpec link(self, scope):
         raise NotImplementedError
@@ -96,7 +100,9 @@ cdef class TypeSpec(object):
             A representation of that value using only primitive types, lists,
             and maps.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            'to_primitive called on unlinked type reference: %r', self
+        )
 
     cpdef object from_primitive(TypeSpec self, object prim_value):
         """Converts a primitive value into a value of this type.
@@ -111,7 +117,9 @@ cdef class TypeSpec(object):
         :returns:
             A value matching this TypeSpec.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            'from_primitive called on unlinked type reference: %r', self
+        )
 
     cpdef void validate(TypeSpec self, object o) except *:
         """Whether an instance of this spec is valid.
@@ -125,4 +133,6 @@ cdef class TypeSpec(object):
             If the value matched the type but did not hold the correct set of
             acceptable values.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            'validate called on unlinked type reference: %r', self
+        )

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -20,53 +20,54 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import abc
+from thriftrw.wire.value cimport Value
 
 __all__ = ['TypeSpec']
 
 
-class TypeSpec(object):
+cdef class TypeSpec(object):
     """Base class for classes representing TypeSpecs.
 
     A TypeSpec knows how to convert values of the corresponding type to and
     from :py:class:`thriftrw.wire.Value` objects.
     """
-    __metaclass__ = abc.ABCMeta
     __slots__ = ()
 
-    @property
-    def name(self):
+    property name:
         """Name of the type referenced by this type spec."""
-        raise NotImplementedError
 
-    @property
-    def ttype_code(self):
+        def __get__(self):
+            raise NotImplementedError
+
+    property ttype_code:
         """Numeric TType used for the type spec.
 
         The value must be from :py:data:`thriftrw.wire.TType`.
         """
-        raise NotImplementedError
 
-    @property
-    def surface(self):
+        def __get__(self):
+            raise NotImplementedError
+
+    property surface:
         """The surface of a type spec.
 
         The surface of a type spec, if non-None is the value associated with
         its name at the top-level in the generated module.
         """
-        raise NotImplementedError
 
-    @abc.abstractmethod
-    def to_wire(self, value):
+        def __get__(self):
+            raise NotImplementedError
+
+    cpdef Value to_wire(TypeSpec self, object value):
         """Converts the given value into a :py:class:`thriftrw.wire.Value`
         object.
 
         :returns thriftrw.wire.Value:
             Wire representation of the value.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def from_wire(self, wire_value):
+    cpdef object from_wire(TypeSpec self, Value wire_value):
         """Converts the given :py:class:`thriftrw.wire.Value` back into the
         original type.
 
@@ -76,13 +77,12 @@ class TypeSpec(object):
             If the type of the wire value does not have the correct Thrift
             type for this type spec.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def link(self, scope):
-        pass
+    cpdef TypeSpec link(self, scope):
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def to_primitive(self, value):
+    cpdef object to_primitive(TypeSpec self, object value):
         """Converts a value matching this type spec into a primitive value.
 
         A primitive value is a text, binary, integer, or float value, or a
@@ -96,9 +96,9 @@ class TypeSpec(object):
             A representation of that value using only primitive types, lists,
             and maps.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def from_primitive(self, prim_value):
+    cpdef object from_primitive(TypeSpec self, object prim_value):
         """Converts a primitive value into a value of this type.
 
         A primitive value is a text, binary, integer, or float value, or a
@@ -111,9 +111,9 @@ class TypeSpec(object):
         :returns:
             A value matching this TypeSpec.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def validate(self, instance):
+    cpdef void validate(TypeSpec self, object o) except *:
         """Whether an instance of this spec is valid.
 
         :param instance:

--- a/thriftrw/spec/check.pxd
+++ b/thriftrw/spec/check.pxd
@@ -1,0 +1,31 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from .base cimport TypeSpec
+
+from thriftrw.wire.value cimport Value
+
+cpdef type_code_matches(TypeSpec type_spec, Value wire_value)
+
+cpdef instanceof_surface(TypeSpec type_spec, object value)
+
+cpdef instanceof_class(TypeSpec type_spec, cls, object value)

--- a/thriftrw/spec/check.pxd
+++ b/thriftrw/spec/check.pxd
@@ -29,3 +29,7 @@ cpdef type_code_matches(TypeSpec type_spec, Value wire_value)
 cpdef instanceof_surface(TypeSpec type_spec, object value)
 
 cpdef instanceof_class(TypeSpec type_spec, cls, object value)
+
+cpdef isiterable(TypeSpec type_spec, object value)
+
+cpdef ismapping(TypeSpec type_spec, object value)

--- a/thriftrw/spec/check.pyx
+++ b/thriftrw/spec/check.pyx
@@ -63,3 +63,17 @@ cpdef instanceof_class(TypeSpec type_spec, cls, object value):
         raise TypeError(
             'Cannot serialize %r into a "%s".' % (value, type_spec.name)
         )
+
+cpdef isiterable(TypeSpec type_spec, object value):
+    """Checks if the given value is iterable."""
+    if not hasattr(value, '__iter__'):
+        raise TypeError(
+            'Cannot serialize %r into a "%s".' % (value, type_spec.name)
+        )
+
+cpdef ismapping(TypeSpec type_spec, object value):
+    """Checks if the given value is iterable."""
+    if not hasattr(value, '__getitem__') or not hasattr(value, 'items'):
+        raise TypeError(
+            'Cannot serialize %r into a "%s".' % (value, type_spec.name)
+        )

--- a/thriftrw/spec/check.pyx
+++ b/thriftrw/spec/check.pyx
@@ -20,11 +20,14 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+from .base cimport TypeSpec
+
+from thriftrw.wire.value cimport Value
 
 __all__ = ['type_code_matches', 'instanceof_surface']
 
 
-def type_code_matches(type_spec, wire_value):
+cpdef type_code_matches(TypeSpec type_spec, Value wire_value):
     """Verifies that the ttype_code for the TypeSpec and the Value matches.
 
     Raises ``ValueError`` if not.
@@ -42,7 +45,7 @@ def type_code_matches(type_spec, wire_value):
         )
 
 
-def instanceof_surface(type_spec, value):
+cpdef instanceof_surface(TypeSpec type_spec, object value):
     """Verifies that the value is an instance of the type's surface.
 
     Raises ``TypeError`` if not.
@@ -55,7 +58,7 @@ def instanceof_surface(type_spec, value):
     instanceof_class(type_spec, type_spec.surface, value)
 
 
-def instanceof_class(type_spec, cls, value):
+cpdef instanceof_class(TypeSpec type_spec, cls, object value):
     if not isinstance(value, cls):
         raise TypeError(
             'Cannot serialize %r into a "%s".' % (value, type_spec.name)

--- a/thriftrw/spec/enum.pxd
+++ b/thriftrw/spec/enum.pxd
@@ -20,19 +20,12 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
-
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class EnumTypeSpec(TypeSpec):
+    cdef readonly unicode name
+    cdef readonly dict items
+    cdef readonly values_to_names
+    cdef public bint linked
+    cdef public object surface

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -26,8 +26,8 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport I32Value, Value
 from .base cimport TypeSpec
+from . cimport check
 
-from . import check
 from ..errors import ThriftCompilerError
 
 __all__ = ['EnumTypeSpec']

--- a/thriftrw/spec/exc.pxd
+++ b/thriftrw/spec/exc.pxd
@@ -23,16 +23,5 @@ from __future__ import absolute_import, unicode_literals, print_function
 from .struct cimport StructTypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
-
-
 cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+    pass

--- a/thriftrw/spec/field.pxd
+++ b/thriftrw/spec/field.pxd
@@ -20,19 +20,16 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from libc.stdint cimport int16_t
+
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class FieldSpec(object):
+    cdef readonly int16_t id
+    cdef readonly unicode name
+    cdef readonly bint required
 
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+    cdef public TypeSpec spec
+    cdef public object default_value
+    cdef public bint linked

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -22,8 +22,8 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport FieldValue
+from .base cimport TypeSpec
 
-from .base import TypeSpec
 from .const import const_value_or_ref
 from .spec_mapper import type_spec_or_ref
 from ..errors import ThriftCompilerError

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -20,14 +20,16 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport FieldValue
 
+from .base import TypeSpec
 from .const import const_value_or_ref
 from .spec_mapper import type_spec_or_ref
 from ..errors import ThriftCompilerError
 
 
-class FieldSpec(object):
+cdef class FieldSpec(object):
     """Specification for a single field on a struct.
 
     .. py:attribute:: id
@@ -51,11 +53,9 @@ class FieldSpec(object):
         Default value of the field if any. None otherwise.
     """
 
-    __slots__ = ('id', 'name', 'spec', 'required', 'default_value', 'linked')
-
     def __init__(self, id, name, spec, required, default_value=None):
         self.id = id
-        self.name = name
+        self.name = unicode(name)
         self.spec = spec
         self.required = required
         self.default_value = default_value
@@ -146,14 +146,13 @@ class FieldSpec(object):
             self.id, self.name, self.spec.name
         )
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
-    def __eq__(self, other):
-        return (
-            self.id == other.id and
-            self.name == other.name and
-            self.spec == other.spec and
-            self.required == other.required and
-            self.default_value == other.default_value and
-            self.linked == other.linked
-        )
+    def __richcmp__(FieldSpec self, FieldSpec other not None, int op):
+        return richcompare(op, [
+            (self.id, other.id),
+            (self.name, other.name),
+            (self.spec, other.spec),
+            (self.required, other.required),
+        ])

--- a/thriftrw/spec/list.pxd
+++ b/thriftrw/spec/list.pxd
@@ -20,19 +20,10 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class ListTypeSpec(TypeSpec):
+    cdef public TypeSpec vspec
+    cdef public bint linked
 
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -20,8 +20,6 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import collections
-
 from . cimport check
 from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
@@ -79,7 +77,7 @@ cdef class ListTypeSpec(TypeSpec):
         return [self.vspec.from_primitive(v) for v in prim_value]
 
     cpdef void validate(ListTypeSpec self, object instance) except *:
-        check.instanceof_class(self, collections.Iterable, instance)
+        check.isiterable(self, instance)
         for v in instance:
             self.vspec.validate(v)
 

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -22,13 +22,12 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import collections
 
+from . cimport check
 from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport ListValue
 from thriftrw.wire.value cimport Value
-
-from . import check
 
 __all__ = ['ListTypeSpec']
 

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -22,16 +22,18 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import collections
 
+from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
+from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport ListValue
+from thriftrw.wire.value cimport Value
 
 from . import check
-from .base import TypeSpec
 
 __all__ = ['ListTypeSpec']
 
 
-class ListTypeSpec(TypeSpec):
+cdef class ListTypeSpec(TypeSpec):
     """Spec for list types.
 
     .. py:attribute:: vspec
@@ -39,8 +41,6 @@ class ListTypeSpec(TypeSpec):
         TypeSpec for the kind of values lists conforming to this spec must
         contain.
     """
-
-    __slots__ = ('vspec', 'linked')
 
     ttype_code = ttype.LIST
     surface = list
@@ -53,7 +53,7 @@ class ListTypeSpec(TypeSpec):
         self.vspec = vspec
         self.linked = False
 
-    def link(self, scope):
+    cpdef TypeSpec link(self, scope):
         if not self.linked:
             self.linked = True
             self.vspec = self.vspec.link(scope)
@@ -63,23 +63,23 @@ class ListTypeSpec(TypeSpec):
     def name(self):
         return 'list<%s>' % self.vspec.name
 
-    def to_wire(self, value):
+    cpdef Value to_wire(ListTypeSpec self, object value):
         return ListValue(
             value_ttype=self.vspec.ttype_code,
             values=[self.vspec.to_wire(v) for v in value],
         )
 
-    def to_primitive(self, value):
+    cpdef object to_primitive(ListTypeSpec self, object value):
         return [self.vspec.to_primitive(x) for x in value]
 
-    def from_wire(self, wire_value):
+    cpdef object from_wire(ListTypeSpec self, Value wire_value):
         check.type_code_matches(self, wire_value)
         return [self.vspec.from_wire(v) for v in wire_value.values]
 
-    def from_primitive(self, prim_value):
+    cpdef object from_primitive(ListTypeSpec self, object prim_value):
         return [self.vspec.from_primitive(v) for v in prim_value]
 
-    def validate(self, instance):
+    cpdef void validate(ListTypeSpec self, object instance) except *:
         check.instanceof_class(self, collections.Iterable, instance)
         for v in instance:
             self.vspec.validate(v)
@@ -87,10 +87,11 @@ class ListTypeSpec(TypeSpec):
     def __str__(self):
         return 'ListTypeSpec(vspec=%r)' % self.vspec
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
-    def __eq__(self, other):
-        return (
-            self.vspec == other.vspec and
-            self.linked == other.linked
-        )
+    def __richcmp__(ListTypeSpec self, ListTypeSpec other not None, int op):
+        return richcompare(op, [
+            (self.vspec, other.vspec),
+        ])
+

--- a/thriftrw/spec/map.pxd
+++ b/thriftrw/spec/map.pxd
@@ -20,19 +20,11 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class MapTypeSpec(TypeSpec):
+    cdef public TypeSpec kspec
+    cdef public TypeSpec vspec
+    cdef public bint linked
 
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -20,8 +20,6 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import collections
-
 from . cimport check
 from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
@@ -98,7 +96,7 @@ cdef class MapTypeSpec(TypeSpec):
         }
 
     cpdef void validate(MapTypeSpec self, object instance) except *:
-        check.instanceof_class(self, collections.Mapping, instance)
+        check.ismapping(self, instance)
         for k, v in instance.items():
             self.kspec.validate(k)
             self.vspec.validate(v)

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -22,12 +22,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import collections
 
+from . cimport check
 from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport MapItem, MapValue, Value
-
-from . import check
 
 __all__ = ['MapTypeSpec']
 

--- a/thriftrw/spec/primitive.pxd
+++ b/thriftrw/spec/primitive.pxd
@@ -20,19 +20,30 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from libc.stdint cimport int8_t
+
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class PrimitiveTypeSpec(TypeSpec):
+    cdef readonly unicode name
+    cdef readonly int8_t code
+    cdef readonly object value_cls
+    cdef readonly object surface
+    cdef readonly object cast
 
 
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
+cdef class _TextualTypeSpec(TypeSpec):
+    pass
 
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
 
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class _TextTypeSpec(_TextualTypeSpec):
+    pass
+
+
+cdef class _BinaryTypeSpec(_TextualTypeSpec):
+    pass
+
+
+cdef class _BoolTypeSpec(TypeSpec):
+    pass

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -20,9 +20,6 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import six
-import numbers
-
 from thriftrw.wire cimport ttype
 from thriftrw.wire.value cimport (
     Value,
@@ -48,10 +45,6 @@ __all__ = [
     'BinaryTypeSpec',
     'TextTypeSpec',
 ]
-
-
-if six.PY3:
-    long = int  # No long in Py3.
 
 
 cdef class PrimitiveTypeSpec(TypeSpec):
@@ -126,12 +119,12 @@ cdef class _TextualTypeSpec(TypeSpec):
         return self
 
     cpdef Value to_wire(_TextualTypeSpec self, object value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, unicode):
             value = value.encode('utf-8')
         return BinaryValue(value)
 
     cpdef void validate(_TextualTypeSpec self, object instance) except *:
-        if not isinstance(instance, (six.binary_type, six.text_type)):
+        if not isinstance(instance, (bytes, unicode)):
             raise TypeError(
                 'Cannot convert %r into a "%s".' % (instance, self.name)
             )
@@ -141,10 +134,10 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
     """TypeSpec for the text type."""
 
     name = 'string'
-    surface = six.text_type
+    surface = unicode
 
     cpdef object to_primitive(_TextTypeSpec self, object value):
-        if isinstance(value, six.binary_type):
+        if isinstance(value, bytes):
             value = value.decode('utf-8')
         return value
 
@@ -153,7 +146,7 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
         return wire_value.value.decode('utf-8')
 
     cpdef object from_primitive(_TextTypeSpec self, object prim_value):
-        if isinstance(prim_value, six.binary_type):
+        if isinstance(prim_value, bytes):
             prim_value = prim_value.decode('utf-8')
         return prim_value
 
@@ -167,10 +160,10 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
 cdef class _BinaryTypeSpec(_TextualTypeSpec):
 
     name = 'binary'
-    surface = six.binary_type
+    surface = bytes
 
     cpdef object to_primitive(_BinaryTypeSpec self, object value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, unicode):
             value = value.encode('utf-8')
         return value
 
@@ -179,7 +172,7 @@ cdef class _BinaryTypeSpec(_TextualTypeSpec):
         return wire_value.value
 
     cpdef object from_primitive(_BinaryTypeSpec self, object prim_value):
-        if isinstance(prim_value, six.text_type):
+        if isinstance(prim_value, unicode):
             prim_value = prim_value.encode('utf-8')
         return prim_value
 
@@ -225,23 +218,23 @@ cdef class _BoolTypeSpec(TypeSpec):
 BoolTypeSpec = _BoolTypeSpec()
 
 ByteTypeSpec = PrimitiveTypeSpec(
-    'byte', ttype.BYTE, ByteValue, numbers.Integral, int
+    'byte', ttype.BYTE, ByteValue, (int, long), int
 )
 
 DoubleTypeSpec = PrimitiveTypeSpec(
-    'double', ttype.DOUBLE, DoubleValue, numbers.Number, float
+    'double', ttype.DOUBLE, DoubleValue, (int, long, float), float
 )
 
 I16TypeSpec = PrimitiveTypeSpec(
-    'i16', ttype.I16, I16Value, numbers.Integral, int
+    'i16', ttype.I16, I16Value, (int, long), int
 )
 
 I32TypeSpec = PrimitiveTypeSpec(
-    'i32', ttype.I32, I32Value, numbers.Integral, int
+    'i32', ttype.I32, I32Value, (int, long), int
 )
 
 I64TypeSpec = PrimitiveTypeSpec(
-    'i64', ttype.I64, I64Value, numbers.Integral, long
+    'i64', ttype.I64, I64Value, (int, long), long
 )
 
 BinaryTypeSpec = _BinaryTypeSpec()

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -35,7 +35,7 @@ from thriftrw.wire.value cimport (
     BinaryValue,
 )
 
-from . import check
+from . cimport check
 from .base cimport TypeSpec
 
 __all__ = [

--- a/thriftrw/spec/reference.pxd
+++ b/thriftrw/spec/reference.pxd
@@ -20,19 +20,9 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
-
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class TypeReference(TypeSpec):
+    cdef readonly name
+    cdef readonly int lineno

--- a/thriftrw/spec/reference.pyx
+++ b/thriftrw/spec/reference.pyx
@@ -28,7 +28,7 @@ from .base cimport TypeSpec
 __all__ = ['TypeReference']
 
 
-cdef class TypeReference(object):
+cdef class TypeReference(TypeSpec):
     """A reference to another type."""
 
     __slots__ = ('name', 'lineno')
@@ -36,32 +36,6 @@ cdef class TypeReference(object):
     def __init__(self, name, lineno):
         self.name = name
         self.lineno = lineno
-
-    cpdef Value to_wire(self, object value):
-        raise NotImplementedError(
-            'to_wire called on unlinked type reference: %r', self
-        )
-
-    cpdef object from_wire(self, Value wire_value):
-        raise NotImplementedError(
-            'from_wire called on unlinked type reference: %r', self
-        )
-
-    cpdef object to_primitive(self, object value):
-        raise NotImplementedError(
-            'to_primitive called on unlinked type reference: %r', self
-        )
-
-    cpdef object from_primitive(self, object prim_value):
-        raise NotImplementedError(
-            'from_primitive called on unlinked type reference: %r', self
-        )
-
-
-    cpdef void validate(self, object o) except *:
-        raise NotImplementedError(
-            'validate called on unlinked type reference: %r', self
-        )
 
     cpdef TypeSpec link(self, scope):
         return scope.resolve_type_spec(self.name, self.lineno)

--- a/thriftrw/spec/reference.pyx
+++ b/thriftrw/spec/reference.pyx
@@ -1,0 +1,85 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+from thriftrw._cython cimport richcompare
+from thriftrw.wire.value cimport Value
+
+from .base cimport TypeSpec
+
+__all__ = ['TypeReference']
+
+
+cdef class TypeReference(object):
+    """A reference to another type."""
+
+    __slots__ = ('name', 'lineno')
+
+    def __init__(self, name, lineno):
+        self.name = name
+        self.lineno = lineno
+
+    cpdef Value to_wire(self, object value):
+        raise NotImplementedError(
+            'to_wire called on unlinked type reference: %r', self
+        )
+
+    cpdef object from_wire(self, Value wire_value):
+        raise NotImplementedError(
+            'from_wire called on unlinked type reference: %r', self
+        )
+
+    cpdef object to_primitive(self, object value):
+        raise NotImplementedError(
+            'to_primitive called on unlinked type reference: %r', self
+        )
+
+    cpdef object from_primitive(self, object prim_value):
+        raise NotImplementedError(
+            'from_primitive called on unlinked type reference: %r', self
+        )
+
+
+    cpdef void validate(self, object o) except *:
+        raise NotImplementedError(
+            'validate called on unlinked type reference: %r', self
+        )
+
+    cpdef TypeSpec link(self, scope):
+        return scope.resolve_type_spec(self.name, self.lineno)
+
+    # It may be worth making this implement the TypeSpec interface and raise
+    # exceptions complaining about unresolved type references, since that's
+    # probably a bug.
+
+    def __str__(self):
+        return 'TypeReference(%s, lineno=%d)' % (
+            self.name, self.lineno
+        )
+
+    def __repr__(self):
+        return str(self)
+
+    def __richcmp__(TypeReference self, TypeReference other not None, int op):
+        return richcompare(op, [
+            (self.name, other.name),
+            (self.lineno, other.lineno),
+        ])

--- a/thriftrw/spec/service.pxd
+++ b/thriftrw/spec/service.pxd
@@ -21,18 +21,39 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from .struct cimport StructTypeSpec
+from .union cimport UnionTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class FunctionArgsSpec(StructTypeSpec):
+    cdef public FunctionSpec function
 
 
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
+cdef class FunctionResultSpec(UnionTypeSpec):
+    cdef public TypeSpec return_spec
+    cdef public list exception_specs
+    cdef public FunctionSpec function
+    cdef public object exception_ids
 
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
 
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class FunctionSpec(object):
+    cdef readonly unicode name
+    cdef public FunctionArgsSpec args_spec
+    cdef public FunctionResultSpec result_spec
+    cdef readonly bint oneway
+    cdef public bint linked
+    cdef public object surface
+    cdef public ServiceSpec service
+
+    cpdef FunctionSpec link(self, scope, ServiceSpec service)
+
+
+cdef class ServiceSpec(object):
+    cdef readonly unicode name
+    cdef public list functions
+    cdef public object parent
+    cdef public dict _functions
+    cdef public bint linked
+    cdef public object surface
+
+    cpdef ServiceSpec link(self, scope)

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -26,8 +26,8 @@ from thriftrw.wire.value cimport Value
 from .field cimport FieldSpec
 from .union cimport UnionTypeSpec
 from .struct cimport StructTypeSpec
+from . cimport check
 
-from . import check
 from .spec_mapper import type_spec_or_ref
 from ..errors import ThriftCompilerError
 from ..errors import UnknownExceptionError

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -22,11 +22,13 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from collections import namedtuple
 
+from thriftrw.wire.value cimport Value
+from .field cimport FieldSpec
+from .union cimport UnionTypeSpec
+from .struct cimport StructTypeSpec
+
 from . import check
 from .spec_mapper import type_spec_or_ref
-from .field import FieldSpec
-from .struct import StructTypeSpec
-from .union import UnionTypeSpec
 from ..errors import ThriftCompilerError
 from ..errors import UnknownExceptionError
 
@@ -39,7 +41,7 @@ __all__ = [
 ]
 
 
-class FunctionArgsSpec(StructTypeSpec):
+cdef class FunctionArgsSpec(StructTypeSpec):
     """Represents the parameters of a service function.
 
     .. py:attribute:: function
@@ -66,8 +68,6 @@ class FunctionArgsSpec(StructTypeSpec):
 
         Added ``result_type`` class attribute to the surface.
     """
-
-    __slots__ = StructTypeSpec.__slots__ + ('function',)
 
     def __init__(self, name, params):
         super(FunctionArgsSpec, self).__init__(name, params)
@@ -109,7 +109,7 @@ class FunctionArgsSpec(StructTypeSpec):
         return spec
 
 
-class FunctionResultSpec(UnionTypeSpec):
+cdef class FunctionResultSpec(UnionTypeSpec):
     """Represents the result of a service function.
 
     .. py:attribute:: return_spec
@@ -146,10 +146,6 @@ class FunctionResultSpec(UnionTypeSpec):
         Added the ``function`` attribute.
     """
 
-    __slots__ = UnionTypeSpec.__slots__ + (
-        'return_spec', 'exception_specs', 'exception_ids', 'function'
-    )
-
     def __init__(self, name, return_spec, exceptions):
         self.return_spec = return_spec
         self.exception_specs = exceptions
@@ -178,7 +174,7 @@ class FunctionResultSpec(UnionTypeSpec):
             name, result_specs, allow_empty=(return_spec is None)
         )
 
-    def from_wire(self, wire_value):
+    cpdef object from_wire(self, Value wire_value):
         check.type_code_matches(self, wire_value)
 
         for field in wire_value.fields:
@@ -237,7 +233,7 @@ class FunctionResultSpec(UnionTypeSpec):
         return cls(result_name, return_spec, exc_specs)
 
 
-class FunctionSpec(object):
+cdef class FunctionSpec(object):
     """Specification of a single function on a service.
 
     .. py:attribute:: name
@@ -280,11 +276,8 @@ class FunctionSpec(object):
         Added the ``oneway`` attribute.
     """
 
-    __slots__ = ('name', 'args_spec', 'result_spec', 'oneway', 'linked',
-                 'surface', 'service')
-
     def __init__(self, name, args_spec, result_spec, oneway):
-        self.name = name
+        self.name = unicode(name)
         self.args_spec = args_spec
         self.result_spec = result_spec
         self.oneway = oneway
@@ -322,7 +315,7 @@ class FunctionSpec(object):
 
         return cls(func.name, args_spec, result_spec, func.oneway)
 
-    def link(self, scope, service):
+    cpdef FunctionSpec link(self, scope, ServiceSpec service):
         if not self.linked:
             self.service = service
             self.linked = True
@@ -346,10 +339,11 @@ class FunctionSpec(object):
             self.name, self.args_spec, self.result_spec
         )
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
 
-class ServiceSpec(object):
+cdef class ServiceSpec(object):
     """Spec for a single service.
 
     .. py:attribute:: name
@@ -376,13 +370,8 @@ class ServiceSpec(object):
     function defined in the service.
     """
 
-    __slots__ = (
-        'name', 'functions', 'parent', 'linked', 'surface',
-        '_functions',
-    )
-
     def __init__(self, name, functions, parent):
-        self.name = name
+        self.name = unicode(name)
         self.functions = functions
         self.parent = parent
 
@@ -410,7 +399,7 @@ class ServiceSpec(object):
 
         return cls(service.name, functions, service.parent)
 
-    def link(self, scope):
+    cpdef ServiceSpec link(self, scope):
         if not self.linked:
             self.linked = True
 
@@ -449,7 +438,8 @@ class ServiceSpec(object):
             self.name, self.functions, self.parent
         )
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
 
 class ServiceFunction(

--- a/thriftrw/spec/set.pxd
+++ b/thriftrw/spec/set.pxd
@@ -20,19 +20,9 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
-
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class SetTypeSpec(TypeSpec):
+    cdef public TypeSpec vspec
+    cdef public bint linked

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -27,8 +27,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport SetValue
 from thriftrw.wire.value cimport Value
-
-from . import check
+from . cimport check
 
 __all__ = ['SetTypeSpec']
 

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -22,22 +22,22 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import collections
 
+from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
+from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport SetValue
+from thriftrw.wire.value cimport Value
 
 from . import check
-from .base import TypeSpec
 
 __all__ = ['SetTypeSpec']
 
 
-class SetTypeSpec(TypeSpec):
+cdef class SetTypeSpec(TypeSpec):
     """
     :param TypeSpec vspec:
         TypeSpec of values stored in the set.
     """
-
-    __slots__ = ('vspec', 'linked')
 
     ttype_code = ttype.SET
 
@@ -45,7 +45,7 @@ class SetTypeSpec(TypeSpec):
         self.vspec = vspec
         self.linked = False
 
-    def link(self, scope):
+    cpdef TypeSpec link(self, scope):
         if not self.linked:
             self.linked = True
             self.vspec = self.vspec.link(scope)
@@ -55,25 +55,35 @@ class SetTypeSpec(TypeSpec):
     def name(self):
         return 'set<%s>' % self.vspec.name
 
-    def to_wire(self, value):
+    cpdef Value to_wire(self, object value):
+        items = []
+        for v in value:
+            items.append(self.vspec.to_wire(v))
         return SetValue(
             value_ttype=self.vspec.ttype_code,
-            values=[self.vspec.to_wire(v) for v in value],
+            values=items,
         )
 
-    def to_primitive(self, value):
-        return [self.vspec.to_primitive(x) for x in value]
+    cpdef object to_primitive(self, object value):
+        items = []
+        for x in value:
+            items.append(self.vspec.to_primitive(x))
+        return items
 
-    def from_wire(self, wire_value):
+    cpdef object from_wire(self, Value wire_value):
         check.type_code_matches(self, wire_value)
-        return set(
-            self.vspec.from_wire(v) for v in wire_value.values
-        )
+        result = set()
+        for v in wire_value.values:
+            result.add(self.vspec.from_wire(v))
+        return result
 
-    def from_primitive(self, prim_value):
-        return set(self.vspec.from_primitive(v) for v in prim_value)
+    cpdef object from_primitive(self, object prim_value):
+        result = set()
+        for v in prim_value:
+            result.add(self.vspec.from_primitive(v))
+        return result
 
-    def validate(self, instance):
+    cpdef void validate(self, object instance) except *:
         check.instanceof_class(self, collections.Iterable, instance)
         for v in instance:
             self.vspec.validate(v)
@@ -81,10 +91,11 @@ class SetTypeSpec(TypeSpec):
     def __str__(self):
         return 'SetTypeSpec(vspec=%r)' % self.vspec
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
-    def __eq__(self, other):
-        return (
-            self.vspec == other.vspec and
-            self.linked == other.linked
-        )
+    def __richcmp__(SetTypeSpec self, SetTypeSpec other not None, int op):
+        return richcompare(op, [
+            (self.vspec, other.vspec),
+        ])
+

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -20,8 +20,6 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import collections
-
 from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
@@ -83,7 +81,7 @@ cdef class SetTypeSpec(TypeSpec):
         return result
 
     cpdef void validate(self, object instance) except *:
-        check.instanceof_class(self, collections.Iterable, instance)
+        check.isiterable(self, instance)
         for v in instance:
             self.vspec.validate(v)
 

--- a/thriftrw/spec/spec_mapper.pyx
+++ b/thriftrw/spec/spec_mapper.pyx
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .reference import TypeReference
-from .map import MapTypeSpec
-from .set import SetTypeSpec
-from .list import ListTypeSpec
+from .reference cimport TypeReference
+from .map cimport MapTypeSpec
+from .set cimport SetTypeSpec
+from .list cimport ListTypeSpec
+
 from .primitive import (
     BoolTypeSpec,
     ByteTypeSpec,

--- a/thriftrw/spec/struct.pxd
+++ b/thriftrw/spec/struct.pxd
@@ -20,19 +20,14 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class StructTypeSpec(TypeSpec):
+    cdef readonly unicode name
+    cdef readonly list fields
+    cdef readonly object base_cls
 
+    cdef public bint linked
+    cdef public object surface
 
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -26,8 +26,8 @@ from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport StructValue
 from .base cimport TypeSpec
 from .field cimport FieldSpec
+from . cimport check
 
-from . import check
 from . import common
 from ..errors import ThriftCompilerError
 

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -21,18 +21,20 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire cimport ttype
+from thriftrw.wire.value cimport Value
+from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport StructValue
+from .base cimport TypeSpec
+from .field cimport FieldSpec
 
 from . import check
 from . import common
-from .base import TypeSpec
-from .field import FieldSpec
 from ..errors import ThriftCompilerError
 
 __all__ = ['StructTypeSpec', 'FieldSpec']
 
 
-class StructTypeSpec(TypeSpec):
+cdef class StructTypeSpec(TypeSpec):
     """A struct is a collection of named fields.
 
     .. py:attribute:: name
@@ -101,10 +103,6 @@ class StructTypeSpec(TypeSpec):
                 # ...
     """
 
-    __slots__ = (
-        'name', 'fields', 'linked', 'surface', 'base_cls',
-    )
-
     ttype_code = ttype.STRUCT
 
     def __init__(self, name, fields, base_cls=None):
@@ -118,13 +116,13 @@ class StructTypeSpec(TypeSpec):
             Base class to use for generates classes. Defaults to ``object``.
         """
 
-        self.name = name
+        self.name = unicode(name)
         self.fields = fields
         self.linked = False
         self.surface = None
         self.base_cls = base_cls or object
 
-    def link(self, scope):
+    cpdef TypeSpec link(self, scope):
         if not self.linked:
             self.linked = True
             self.fields = [field.link(scope) for field in self.fields]
@@ -159,7 +157,7 @@ class StructTypeSpec(TypeSpec):
             ))
         return cls(struct.name, fields)
 
-    def to_wire(self, struct):
+    cpdef Value to_wire(self, object struct):
         fields = []
 
         for field in self.fields:
@@ -170,18 +168,18 @@ class StructTypeSpec(TypeSpec):
 
         return StructValue(fields)
 
-    def to_primitive(self, union):
+    cpdef object to_primitive(self, object struct):
         prim = {}
 
         for field in self.fields:
-            value = getattr(union, field.name)
+            value = getattr(struct, field.name)
             if value is None:
                 continue
 
             prim[field.name] = field.spec.to_primitive(value)
         return prim
 
-    def from_wire(self, wire_value):
+    cpdef object from_wire(self, Value wire_value):
         check.type_code_matches(self, wire_value)
         kwargs = {}
         for field in self.fields:
@@ -192,7 +190,7 @@ class StructTypeSpec(TypeSpec):
 
         return self.surface(**kwargs)
 
-    def from_primitive(self, prim_value):
+    cpdef object from_primitive(self, object prim_value):
         kwargs = {}
 
         for field in self.fields:
@@ -203,7 +201,7 @@ class StructTypeSpec(TypeSpec):
 
         return self.surface(**kwargs)
 
-    def validate(self, instance):
+    cpdef void validate(self, object instance) except *:
         check.instanceof_surface(self, instance)
 
         for field in self.fields:
@@ -223,15 +221,15 @@ class StructTypeSpec(TypeSpec):
             self.__class__.__name__, self.name, self.fields
         )
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
-    def __eq__(self, other):
-        return (
-            self.name == other.name and
-            self.fields == other.fields and
-            self.base_cls == other.base_cls and
-            self.linked == other.linked
-        )
+    def __richcmp__(StructTypeSpec self, StructTypeSpec other not None, int op):
+        return richcompare(op, [
+            (self.name, other.name),
+            (self.fields, other.fields),
+            (self.base_cls, other.base_cls),
+        ])
 
 
 def struct_init(cls_name, field_names, field_defaults, base_cls, validate):

--- a/thriftrw/spec/typedef.pxd
+++ b/thriftrw/spec/typedef.pxd
@@ -20,19 +20,9 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
-
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+cdef class TypedefTypeSpec(TypeSpec):
+    cdef readonly unicode name
+    cdef public TypeSpec target_spec

--- a/thriftrw/spec/typedef.pyx
+++ b/thriftrw/spec/typedef.pyx
@@ -46,21 +46,6 @@ cdef class TypedefTypeSpec(TypeSpec):
     cpdef TypeSpec link(self, scope):
         return self.target_spec.link(scope)
 
-    cpdef Value to_wire(TypedefTypeSpec self, object value):
-        return self.target_spec.to_wire(value)
-
-    cpdef object from_wire(TypedefTypeSpec self, Value wire_value):
-        return self.target_spec.from_wire(wire_value)
-
-    cpdef object to_primitive(TypedefTypeSpec self, object value):
-        return self.target_spec.to_primitive(value)
-
-    cpdef object from_primitive(TypedefTypeSpec self, object prim_value):
-        return self.target_spec.from_primitive(prim_value)
-
-    cpdef void validate(TypedefTypeSpec self, object o) except *:
-        self.target_spec.validate(o)
-
     def __str__(self):
         return 'TypedefTypeSpec(%r, %r)' % (self.name, self.target_spec)
 

--- a/thriftrw/spec/typedef.pyx
+++ b/thriftrw/spec/typedef.pyx
@@ -22,8 +22,8 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport Value
-
 from .base cimport TypeSpec
+
 from .spec_mapper import type_spec_or_ref
 
 

--- a/thriftrw/spec/union.pxd
+++ b/thriftrw/spec/union.pxd
@@ -20,19 +20,13 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-from .struct cimport StructTypeSpec
+from .base cimport TypeSpec
 
 
-__all__ = ['ExceptionTypeSpec']
+cdef class UnionTypeSpec(TypeSpec):
+    cdef readonly unicode name
+    cdef readonly list fields
+    cdef readonly bint allow_empty
 
-
-cdef class ExceptionTypeSpec(StructTypeSpec):
-    """Spec for ``exception`` types defined in the Thrift file.
-
-    This is exactly the same as :py:class:`thriftrw.spec.StructTypeSpec`
-    except that the generated class inherits the ``Exception`` class.
-    """
-
-    def __init__(self, *args, **kwargs):
-        kwargs['base_cls'] = Exception
-        super(ExceptionTypeSpec, self).__init__(*args, **kwargs)
+    cdef public bint linked
+    cdef public object surface

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -21,18 +21,20 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire cimport ttype
+from thriftrw.wire.value cimport Value
+from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport StructValue
+from .base cimport TypeSpec
+from .field cimport FieldSpec
 
 from . import check
 from . import common
-from .base import TypeSpec
-from .field import FieldSpec
 from ..errors import ThriftCompilerError
 
 __all__ = ['UnionTypeSpec', 'FieldSpec']
 
 
-class UnionTypeSpec(TypeSpec):
+cdef class UnionTypeSpec(TypeSpec):
     """Spec for Thrift unions.
 
     The surface for union types is a class with the following:
@@ -87,18 +89,16 @@ class UnionTypeSpec(TypeSpec):
                 # ...
     """
 
-    __slots__ = ('name', 'fields', 'linked', 'surface', 'allow_empty')
-
     ttype_code = ttype.STRUCT
 
     def __init__(self, name, fields, allow_empty=None):
-        self.name = name
+        self.name = unicode(name)
         self.fields = fields
         self.linked = False
         self.surface = None
         self.allow_empty = allow_empty
 
-    def link(self, scope):
+    cpdef TypeSpec link(self, scope):
         if not self.linked:
             self.linked = True
             self.fields = [field.link(scope) for field in self.fields]
@@ -149,7 +149,7 @@ class UnionTypeSpec(TypeSpec):
             ))
         return cls(union.name, fields)
 
-    def to_wire(self, union):
+    cpdef Value to_wire(UnionTypeSpec self, object union):
         fields = []
 
         for field in self.fields:
@@ -160,7 +160,7 @@ class UnionTypeSpec(TypeSpec):
 
         return StructValue(fields)
 
-    def to_primitive(self, union):
+    cpdef object to_primitive(UnionTypeSpec self, object union):
         for field in self.fields:
             value = getattr(union, field.name)
             if value is None:
@@ -169,7 +169,7 @@ class UnionTypeSpec(TypeSpec):
             return {field.name: field.spec.to_primitive(value)}
         return {}
 
-    def from_wire(self, wire_value):
+    cpdef object from_wire(UnionTypeSpec self, Value wire_value):
         check.type_code_matches(self, wire_value)
         kwargs = {}
         for field in self.fields:
@@ -181,7 +181,7 @@ class UnionTypeSpec(TypeSpec):
 
         return self.surface(**kwargs)
 
-    def from_primitive(self, prim_value):
+    cpdef object from_primitive(UnionTypeSpec self, object prim_value):
         kwargs = {}
 
         for field in self.fields:
@@ -193,7 +193,7 @@ class UnionTypeSpec(TypeSpec):
 
         return self.surface(**kwargs)
 
-    def validate(self, instance):
+    cpdef void validate(UnionTypeSpec self, object instance) except *:
         check.instanceof_surface(self, instance)
 
         found = 0
@@ -225,14 +225,14 @@ class UnionTypeSpec(TypeSpec):
             self.__class__.__name__, self.name, self.fields
         )
 
-    __repr__ = __str__
+    def __repr__(self):
+        return str(self)
 
-    def __eq__(self, other):
-        return (
-            self.name == other.name and
-            self.fields == other.fields and
-            self.linked == other.linked
-        )
+    def __richcmp__(UnionTypeSpec self, UnionTypeSpec other not None, int op):
+        return richcompare(op, [
+            (self.name, other.name),
+            (self.fields, other.fields),
+        ])
 
 
 def union_init(cls_name, fields, allow_empty, validate):

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -26,8 +26,8 @@ from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport StructValue
 from .base cimport TypeSpec
 from .field cimport FieldSpec
+from . cimport check
 
-from . import check
 from . import common
 from ..errors import ThriftCompilerError
 


### PR DESCRIPTION
Making specs proper cdef classes and cythonizing validation helpers improves performance measurably.

Before:
```
---------------------------------------------- benchmark: 4 tests ---------------------------------------------
Name (time in ms)            Min       Max      Mean  StdDev    Median     IQR  Outliers(*)  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------
test_binary_dumps       125.0720  128.1979  126.4458  1.1813  126.4951  1.5541          2;0       5           1
test_binary_loads       495.3928  510.6471  502.1579  5.5150  501.4639  5.5938          2;0       5           1
---------------------------------------------------------------------------------------------------------------
```

After:
```
---------------------------------------------- benchmark: 4 tests ---------------------------------------------
Name (time in ms)            Min       Max      Mean  StdDev    Median     IQR  Outliers(*)  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------
test_binary_dumps        62.5141   70.6010   65.9622  3.2110   66.6659  4.5194          2;0       5           1
test_binary_loads       270.0222  276.7150  273.3597  2.8138  273.1581  4.8929          2;0       5           1
---------------------------------------------------------------------------------------------------------------
```

(This is the same benchmark as #109 but without the changes from that PR.)