### PR TITLE
Use str, not unicode for type names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Releases
 ========
 
+1.2.2 (unreleased)
+------------------
+
+- Re-add the changes from 1.2.0 with a fix. Serialization and deserialization
+  should be fast again.
+
+
+1.2.1 (2016-02-11)
+------------------
+
+- Revert changes made in 1.2.0 because they unintentionally break some
+  str/unicode concerns in TypeSpecs.
+
+
 1.2.0 (2016-02-11)
 ------------------
 

--- a/tests/test_names_match_type.py
+++ b/tests/test_names_match_type.py
@@ -18,18 +18,36 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import absolute_import, unicode_literals, print_function
+"""
+Tests in this file just make sure that the names for functions and types are
+valid for use in ``type()`` calls and assignable to ``__name__``.
+"""
 
-from libc.stdint cimport int16_t
+from __future__ import absolute_import, print_function
+# We intentionally don't add unicode_literals here because we want the system
+# to use whatever the default is for that version of Python.
 
-from .base cimport TypeSpec
+import pytest
 
 
-cdef class FieldSpec(object):
-    cdef readonly int16_t id
-    cdef readonly str name
-    cdef readonly bint required
+@pytest.fixture
+def service(loads):
+    return loads('''
+        struct Item {}
 
-    cdef public TypeSpec spec
-    cdef public object default_value
-    cdef public bint linked
+        service Service { void someMethod() }
+    ''')
+
+
+def test_function_spec_name(service):
+    func_spec = service.Service.someMethod.spec
+
+    def some_func():
+        pass
+
+    some_func.__name__ = func_spec.name
+
+
+def test_type_spec_name(service):
+    type_spec = service.Item.type_spec
+    type(type_spec.name, (), {})

--- a/thriftrw/__init__.py
+++ b/thriftrw/__init__.py
@@ -28,6 +28,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 from .loader import load
 from .loader import install
 
-__version__ = '1.2.0'
+__version__ = '1.2.2.dev0'
 
 __all__ = ['load', 'install']

--- a/thriftrw/spec/enum.pxd
+++ b/thriftrw/spec/enum.pxd
@@ -24,7 +24,7 @@ from .base cimport TypeSpec
 
 
 cdef class EnumTypeSpec(TypeSpec):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef readonly dict items
     cdef readonly values_to_names
     cdef public bint linked

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -118,7 +118,7 @@ cdef class EnumTypeSpec(TypeSpec):
         assert name
         assert items is not None
 
-        self.name = unicode(name)
+        self.name = str(name)
         self.items = items
 
         values_to_names = defaultdict(lambda: [])

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -55,7 +55,7 @@ cdef class FieldSpec(object):
 
     def __init__(self, id, name, spec, required, default_value=None):
         self.id = id
-        self.name = unicode(name)
+        self.name = str(name)
         self.spec = spec
         self.required = required
         self.default_value = default_value

--- a/thriftrw/spec/primitive.pxd
+++ b/thriftrw/spec/primitive.pxd
@@ -26,7 +26,7 @@ from .base cimport TypeSpec
 
 
 cdef class PrimitiveTypeSpec(TypeSpec):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef readonly int8_t code
     cdef readonly object value_cls
     cdef readonly object surface

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -65,7 +65,7 @@ cdef class PrimitiveTypeSpec(TypeSpec):
             If provided, this is used to cast values into a standard shape
             before passing them to ``value_cls``
         """
-        self.name = unicode(name)
+        self.name = str(name)
         self.code = code
         self.value_cls = value_cls
         self.surface = surface
@@ -133,7 +133,7 @@ cdef class _TextualTypeSpec(TypeSpec):
 cdef class _TextTypeSpec(_TextualTypeSpec):
     """TypeSpec for the text type."""
 
-    name = 'string'
+    name = str('string')
     surface = unicode
 
     cpdef object to_primitive(_TextTypeSpec self, object value):
@@ -159,7 +159,7 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
 
 cdef class _BinaryTypeSpec(_TextualTypeSpec):
 
-    name = 'binary'
+    name = str('binary')
     surface = bytes
 
     cpdef object to_primitive(_BinaryTypeSpec self, object value):
@@ -185,7 +185,7 @@ cdef class _BinaryTypeSpec(_TextualTypeSpec):
 
 cdef class _BoolTypeSpec(TypeSpec):
 
-    name = 'bool'
+    name = str('bool')
     surface = bool
     ttype_code = ttype.BOOL
 

--- a/thriftrw/spec/reference.pxd
+++ b/thriftrw/spec/reference.pxd
@@ -24,5 +24,5 @@ from .base cimport TypeSpec
 
 
 cdef class TypeReference(TypeSpec):
-    cdef readonly name
+    cdef readonly str name
     cdef readonly int lineno

--- a/thriftrw/spec/reference.pyx
+++ b/thriftrw/spec/reference.pyx
@@ -34,7 +34,7 @@ cdef class TypeReference(TypeSpec):
     __slots__ = ('name', 'lineno')
 
     def __init__(self, name, lineno):
-        self.name = name
+        self.name = str(name)
         self.lineno = lineno
 
     cpdef TypeSpec link(self, scope):

--- a/thriftrw/spec/service.pxd
+++ b/thriftrw/spec/service.pxd
@@ -37,7 +37,7 @@ cdef class FunctionResultSpec(UnionTypeSpec):
 
 
 cdef class FunctionSpec(object):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef public FunctionArgsSpec args_spec
     cdef public FunctionResultSpec result_spec
     cdef readonly bint oneway
@@ -49,7 +49,7 @@ cdef class FunctionSpec(object):
 
 
 cdef class ServiceSpec(object):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef public list functions
     cdef public object parent
     cdef public dict _functions

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -277,7 +277,7 @@ cdef class FunctionSpec(object):
     """
 
     def __init__(self, name, args_spec, result_spec, oneway):
-        self.name = unicode(name)
+        self.name = str(name)
         self.args_spec = args_spec
         self.result_spec = result_spec
         self.oneway = oneway
@@ -371,7 +371,7 @@ cdef class ServiceSpec(object):
     """
 
     def __init__(self, name, functions, parent):
-        self.name = unicode(name)
+        self.name = str(name)
         self.functions = functions
         self.parent = parent
 
@@ -416,7 +416,7 @@ cdef class ServiceSpec(object):
             self._functions = {}
             for f in self.functions:
                 name = f.name
-                if not isinstance(name, bytes):
+                if isinstance(name, unicode):
                     name = name.encode('utf-8')
                 self._functions[name] = f
 
@@ -429,7 +429,7 @@ cdef class ServiceSpec(object):
 
         .. versionadded:: 1.0
         """
-        if not isinstance(name, bytes):
+        if isinstance(name, unicode):
             name = name.encode('utf-8')
         return self._functions.get(name, None)
 

--- a/thriftrw/spec/struct.pxd
+++ b/thriftrw/spec/struct.pxd
@@ -24,7 +24,7 @@ from .base cimport TypeSpec
 
 
 cdef class StructTypeSpec(TypeSpec):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef readonly list fields
     cdef readonly object base_cls
 

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -116,7 +116,7 @@ cdef class StructTypeSpec(TypeSpec):
             Base class to use for generates classes. Defaults to ``object``.
         """
 
-        self.name = unicode(name)
+        self.name = str(name)
         self.fields = fields
         self.linked = False
         self.surface = None

--- a/thriftrw/spec/typedef.pxd
+++ b/thriftrw/spec/typedef.pxd
@@ -24,5 +24,5 @@ from .base cimport TypeSpec
 
 
 cdef class TypedefTypeSpec(TypeSpec):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef public TypeSpec target_spec

--- a/thriftrw/spec/typedef.pyx
+++ b/thriftrw/spec/typedef.pyx
@@ -35,7 +35,7 @@ cdef class TypedefTypeSpec(TypeSpec):
     """
 
     def __init__(self, name, target_spec):
-        self.name = unicode(name)
+        self.name = str(name)
         self.target_spec = target_spec
 
     @classmethod

--- a/thriftrw/spec/union.pxd
+++ b/thriftrw/spec/union.pxd
@@ -24,7 +24,7 @@ from .base cimport TypeSpec
 
 
 cdef class UnionTypeSpec(TypeSpec):
-    cdef readonly unicode name
+    cdef readonly str name
     cdef readonly list fields
     cdef readonly bint allow_empty
 

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -92,7 +92,7 @@ cdef class UnionTypeSpec(TypeSpec):
     ttype_code = ttype.STRUCT
 
     def __init__(self, name, fields, allow_empty=None):
-        self.name = unicode(name)
+        self.name = str(name)
         self.fields = fields
         self.linked = False
         self.surface = None


### PR DESCRIPTION
This fixes the issue from 1.2.0.

I added a test case that fails on 1.2.0 but passes with these changes. Tested this manually against tchannel-python master as well.

Ignore the merge conflict. I'll merge this manually.