### PR TITLE
Fix order of arguments in struct docstrings.

### DIFF
--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -143,6 +143,7 @@ def test_link_simple(scope):
 
     SimpleStruct = spec.surface
     assert SimpleStruct.type_spec is spec
+    assert 'SimpleStruct(a, c, b=None, d=None)' in SimpleStruct.__doc__
 
 
 def test_load_simple(loads):
@@ -169,6 +170,8 @@ def test_load_simple(loads):
 
     assert SimpleStruct('hello', 42) == SimpleStruct('hello', 42)
     assert SimpleStruct('hello', 42) != SimpleStruct('world', 42)
+
+    assert 'SimpleStruct(a, c, b=None, d=None)' in SimpleStruct.__doc__
 
 
 def test_simple_convert(loads):
@@ -200,6 +203,8 @@ def test_simple_convert(loads):
 
         assert spec.from_wire(wire_value) == value
         assert SimpleStruct.from_primitive(prim_value) == value
+
+    assert 'SimpleStruct(a, b=None)' in SimpleStruct.__doc__
 
 
 def test_required_field_missing(loads):
@@ -293,6 +298,11 @@ def test_default_values(loads):
         assert spec.from_wire(wire_value) == value
         assert Struct.from_primitive(prim_value) == value
 
+    assert (
+        'DefaultStruct(requiredField, optionalField=None, '
+        'optionalFieldWithDefault=None, requiredFieldWithDefault=None)'
+    ) in Struct.__doc__
+
 
 def test_default_binary_value(loads):
     Struct = loads('''struct Struct {
@@ -309,6 +319,11 @@ def test_constructor_behavior(loads):
         3: required binary requiredFieldWithDefault = "";
         4: required string requiredField;
     }''').ConstructorStruct
+
+    assert (
+        'ConstructorStruct(requiredField, optionalField=None, '
+        'optionalFieldWithDefault=None, requiredFieldWithDefault=None)'
+    ) in Struct.__doc__
 
     with pytest.raises(TypeError) as exc_info:
         Struct()

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -351,7 +351,6 @@ def struct_init(cls_name, field_names, field_defaults, base_cls, validate):
         # are assigned.
         validate(self)
 
-    # TODO reasonable docstring
     return __init__
 
 
@@ -370,17 +369,15 @@ def struct_docstring(cls_name, required_fields, optional_fields):
         optional_section = '\n'.join(
             [''] +
             ['\nThe following arguments are optional:\n'] +
-            ['-   %s (default: %s)' % pair
-             for pair in optional_fields.items()]
+            ['-   %s (default: %s)' % pair for pair in optional_fields]
         )
 
     param_list = (
         list(required_fields) +
-        ['%s=None' % name for name in optional_fields.keys()]
+        ['%s=None' % name for name, value in optional_fields]
     )
 
     header = '%s(%s)' % (cls_name, ', '.join(param_list))
-
     return header + required_section + optional_section
 
 
@@ -436,7 +433,7 @@ def struct_cls(struct_spec, scope):
     struct_dct['__doc__'] = struct_docstring(
         struct_spec.name,
         required_fields,
-        dict(zip(optional_fields, field_defaults)),
+        list(zip(optional_fields, field_defaults)),
     )
 
     # TODO generate a reasonable docstring for the class too.


### PR DESCRIPTION
Using a `dict` broke ordering of optional arguments.

Resolves #118.