### PR TITLE
Use streaming API to encode and decode values. In addition, optimize validation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules
 *.so
 .benchmarks/
 .coverage
+.idea/
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - TOX_ENV=py33
     - TOX_ENV=py34
     - TOX_ENV=pypy
-    - TOX_ENV=pypy3
     - TOX_ENV=cover
     - TOX_ENV=flake8
     - TOX_ENV=docs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,13 @@ Releases
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Optimized serialization and deserialization performance by removing an
+  unnecessary intermediate layer.
+- Optimized validation at object construction time by skipping the parsing
+  of nested structs and unions since they would have been validated already
+  anyway.
+- Due to build incompatibility issues, pypy3 support is temporarily being
+  dropped. The library is unlikely to break, but no guarantees exist.
 
 
 1.3.0 (2016-09-13)

--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -25,14 +25,29 @@ import pytest
 from thriftrw.errors import ThriftProtocolError
 from thriftrw.errors import EndOfInputError
 from thriftrw.protocol.binary import BinaryProtocol
+from thriftrw._buffer import ReadBuffer, WriteBuffer
 from thriftrw.wire import ttype
 from thriftrw.wire import value
 from thriftrw.wire import Message
 from thriftrw.wire.mtype import CALL, REPLY, EXCEPTION, ONEWAY
+from thriftrw.spec.primitive import (
+    BinaryTypeSpec as sbin,
+    BoolTypeSpec as sbool,
+    ByteTypeSpec as sbyte,
+    DoubleTypeSpec as sdouble,
+    I16TypeSpec as si16,
+    I32TypeSpec as si32,
+    I64TypeSpec as si64,
+)
+
 
 from ..util.value import (
-    vbool, vbyte, vi16, vi32, vi64, vdouble, vbinary, vlist, vmap, vset,
+    vbool, vbyte, vi16, vi32, vi64, vdouble, vbinary, vlist,
     vstruct,
+)
+
+from ..util.spec import (
+    smap, slist, sstruct, sset
 )
 
 
@@ -42,119 +57,140 @@ def reader_writer_ids(x):
     return ttype.name_of(x)
 
 
-@pytest.mark.parametrize('typ, bs, value', [
+@pytest.mark.parametrize('typ, bs, spec, value', [
     # bool
-    (ttype.BOOL, [0x01], vbool(True)),
-    (ttype.BOOL, [0x00], vbool(False)),
+    (ttype.BOOL, [0x01], sbool, vbool(True)),
+    (ttype.BOOL, [0x00], sbool, vbool(False)),
 
     # byte
-    (ttype.BYTE, [0x00], vbyte(0)),
-    (ttype.BYTE, [0x01], vbyte(1)),
-    (ttype.BYTE, [0xff], vbyte(-1)),
-    (ttype.BYTE, [0x7f], vbyte(127)),
-    (ttype.BYTE, [0x80], vbyte(-128)),
+    (ttype.BYTE, [0x00], sbyte, vbyte(0)),
+    (ttype.BYTE, [0x01], sbyte, vbyte(1)),
+    (ttype.BYTE, [0xff], sbyte, vbyte(-1)),
+    (ttype.BYTE, [0x7f], sbyte, vbyte(127)),
+    (ttype.BYTE, [0x80], sbyte, vbyte(-128)),
 
     # i16
-    (ttype.I16, [0x00, 0x01], vi16(1)),
-    (ttype.I16, [0x00, 0xff], vi16(255)),
-    (ttype.I16, [0x01, 0x00], vi16(256)),
-    (ttype.I16, [0x01, 0x01], vi16(257)),
-    (ttype.I16, [0x7f, 0xff], vi16(32767)),
-    (ttype.I16, [0xff, 0xff], vi16(-1)),
-    (ttype.I16, [0xff, 0xfe], vi16(-2)),
-    (ttype.I16, [0xff, 0x00], vi16(-256)),
-    (ttype.I16, [0xff, 0x01], vi16(-255)),
-    (ttype.I16, [0x80, 0x00], vi16(-32768)),
+    (ttype.I16, [0x00, 0x01], si16, vi16(1)),
+    (ttype.I16, [0x00, 0xff], si16, vi16(255)),
+    (ttype.I16, [0x01, 0x00], si16, vi16(256)),
+    (ttype.I16, [0x01, 0x01], si16, vi16(257)),
+    (ttype.I16, [0x7f, 0xff], si16, vi16(32767)),
+    (ttype.I16, [0xff, 0xff], si16, vi16(-1)),
+    (ttype.I16, [0xff, 0xfe], si16, vi16(-2)),
+    (ttype.I16, [0xff, 0x00], si16, vi16(-256)),
+    (ttype.I16, [0xff, 0x01], si16, vi16(-255)),
+    (ttype.I16, [0x80, 0x00], si16, vi16(-32768)),
 
     # i32
-    (ttype.I32, [0x00, 0x00, 0x00, 0x01], vi32(1)),
-    (ttype.I32, [0x00, 0x00, 0x00, 0xff], vi32(255)),
-    (ttype.I32, [0x00, 0x00, 0xff, 0xff], vi32(65535)),
-    (ttype.I32, [0x00, 0xff, 0xff, 0xff], vi32(16777215)),
-    (ttype.I32, [0x7f, 0xff, 0xff, 0xff], vi32(2147483647)),
-    (ttype.I32, [0xff, 0xff, 0xff, 0xff], vi32(-1)),
-    (ttype.I32, [0xff, 0xff, 0xff, 0x00], vi32(-256)),
-    (ttype.I32, [0xff, 0xff, 0x00, 0x00], vi32(-65536)),
-    (ttype.I32, [0xff, 0x00, 0x00, 0x00], vi32(-16777216)),
-    (ttype.I32, [0x80, 0x00, 0x00, 0x00], vi32(-2147483648)),
+    (ttype.I32, [0x00, 0x00, 0x00, 0x01], si32, vi32(1)),
+    (ttype.I32, [0x00, 0x00, 0x00, 0xff], si32, vi32(255)),
+    (ttype.I32, [0x00, 0x00, 0xff, 0xff], si32, vi32(65535)),
+    (ttype.I32, [0x00, 0xff, 0xff, 0xff], si32, vi32(16777215)),
+    (ttype.I32, [0x7f, 0xff, 0xff, 0xff], si32, vi32(2147483647)),
+    (ttype.I32, [0xff, 0xff, 0xff, 0xff], si32, vi32(-1)),
+    (ttype.I32, [0xff, 0xff, 0xff, 0x00], si32, vi32(-256)),
+    (ttype.I32, [0xff, 0xff, 0x00, 0x00], si32, vi32(-65536)),
+    (ttype.I32, [0xff, 0x00, 0x00, 0x00], si32, vi32(-16777216)),
+    (ttype.I32, [0x80, 0x00, 0x00, 0x00], si32, vi32(-2147483648)),
 
     # i64
     (ttype.I64,
      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01],
+     si64,
      vi64(1)),
     (ttype.I64,
      [0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(4294967295)),
     (ttype.I64,
      [0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(1099511627775)),
     (ttype.I64,
      [0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(281474976710655)),
     (ttype.I64,
      [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(72057594037927935)),
     (ttype.I64,
      [0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(9223372036854775807)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(-1)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-4294967296)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-1099511627776)),
     (ttype.I64,
      [0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-281474976710656)),
     (ttype.I64,
      [0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-72057594037927936)),
     (ttype.I64,
      [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-9223372036854775808)),
 
     # double
     (ttype.DOUBLE,
      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     sdouble,
      vdouble(0.0)),
     (ttype.DOUBLE,
      [0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     sdouble,
      vdouble(1.0)),
     (ttype.DOUBLE,
      [0x3f, 0xf0, 0x0, 0x0, 0x0, 0x6, 0xdf, 0x38],
+     sdouble,
      vdouble(1.0000000001)),
     (ttype.DOUBLE,
      [0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a],
+     sdouble,
      vdouble(1.1)),
     (ttype.DOUBLE,
      [0xbf, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a],
+     sdouble,
      vdouble(-1.1)),
     (ttype.DOUBLE,
      [0x40, 0x9, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18],
+     sdouble,
      vdouble(3.141592653589793)),
     (ttype.DOUBLE,
      [0xbf, 0xf0, 0x0, 0x0, 0x0, 0x6, 0xdf, 0x38],
+     sdouble,
      vdouble(-1.0000000001)),
 
     # binary = len:4 (.){len}
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x00], vbinary(b'')),
+    (ttype.BINARY, [0x00, 0x00, 0x00, 0x00], sbin, vbinary(b'')),
     (ttype.BINARY, [
         0x00, 0x00, 0x00, 0x05,         # len:4 = 5
         0x68, 0x65, 0x6c, 0x6c, 0x6f,   # 'h', 'e', 'l', 'l', 'o'
-    ], vbinary(b'hello')),
+    ], sbin, vbinary(b'hello')),
 
     # struct = (type:1 id:2 value)* stop
     # stop = 0
-    (ttype.STRUCT, [0x00], vstruct()),
+    (ttype.STRUCT, [0x00], sstruct(''), vstruct()),
     (ttype.STRUCT, [
         0x02,        # type:1 = bool
         0x00, 0x01,  # id:2 = 1
         0x01,        # value = true
         0x00,        # stop
-    ], vstruct((1, ttype.BOOL, vbool(True)))),
+     ],
+     sstruct("1: optional bool param"),
+     vstruct((1, ttype.BOOL, vbool(True)))),
     (ttype.STRUCT, [
         0x06,           # type:1 = i16
         0x00, 0x01,     # id:2 = 1
@@ -177,58 +213,19 @@ def reader_writer_ids(x):
         # </list>
 
         0x00,           # stop
-    ], vstruct(
+    ], sstruct("1: optional i16 p1; 2: optional list<binary> p2;"), vstruct(
         (1, ttype.I16, vi16(42)),
         (2, ttype.LIST, vlist(
             ttype.BINARY, vbinary(b'foo'), vbinary(b'bar'))),
     )),
 
-    # map = ktype:1 vtype:1 count:4 (key value){count}
-    (ttype.MAP, [0x0A, 0X0B, 0x00, 0x00, 0x00, 0x00],
-     vmap(ttype.I64, ttype.BINARY)),
-    (ttype.MAP, [
-        0x0B,   # ktype = binary
-        0x0F,   # vtype = list
-        0x00, 0x00, 0x00, 0x02,   # count:4 = 2
-
-        # <item>
-        # <key>
-        0x00, 0x00, 0x00, 0x01,  # len:4 = 1
-        0x61,                    # 'a'
-        # </key>
-        # <value>
-        0x03,                    # type:1 = byte
-        0x00, 0x00, 0x00, 0x01,  # count:4 = 1
-        0x01,                    # 1
-        # </value>
-        # </item>
-
-        # <item>
-        # <key>
-        0x00, 0x00, 0x00, 0x01,  # len:4 = 1
-        0x62,                    # 'b'
-        # </key>
-        # <value>
-        0x06,                    # type:1 = 6
-        0x00, 0x00, 0x00, 0x02,  # count:4 = 2
-        0x00, 0x02,              # 2
-        0x00, 0x03,              # 3
-        # </value>
-        # </item>
-    ], vmap(
-        ttype.BINARY, ttype.LIST,
-        (vbinary(b'a'), vlist(ttype.BYTE, vbyte(1))),
-        (vbinary(b'b'), vlist(ttype.I16, vi16(2), vi16(3))),
-    )),
-
-    # set = vtype:1 count:4 (value){count)
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00, 0x00], vset(ttype.BOOL)),
-    (ttype.SET, [
-        0x02, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x01
-    ], vset(ttype.BOOL, vbool(True), vbool(False), vbool(True))),
-
     # list = vtype:1 count:4 (value){count}
-    (ttype.LIST, [0x0C, 0x00, 0x00, 0x00, 0x00], vlist(ttype.STRUCT)),
+    (
+            ttype.LIST,
+            [0x0C, 0x00, 0x00, 0x00, 0x00],
+            slist(sstruct('')),
+            vlist(ttype.STRUCT)
+    ),
     (ttype.LIST, [
         0x0C,                       # vtype:1 = struct
         0x00, 0x00, 0x00, 0x02,     # count:4 = 2
@@ -256,13 +253,13 @@ def reader_writer_ids(x):
 
         0x00,        # stop
         # </struct>
-    ], vlist(
+    ], slist(sstruct("1: optional i16 p1; 2: optional i32 p2")), vlist(
         ttype.STRUCT,
         vstruct((1, ttype.I16, vi16(1)), (2, ttype.I32, vi32(2))),
         vstruct((1, ttype.I16, vi16(3)), (2, ttype.I32, vi32(4))),
     )),
 ], ids=reader_writer_ids)
-def test_reader_and_writer(typ, bs, value):
+def test_reader_and_writer(typ, bs, spec, value):
     """Test serialization and deserialization of all samples."""
     bs = bytes(bytearray(bs))
 
@@ -274,61 +271,101 @@ def test_reader_and_writer(typ, bs, value):
     result = protocol.serialize_value(value)
     assert bs == result
 
+    buffer = ReadBuffer(bs)
+    deserialized = spec.read_from(protocol.reader(buffer))
+    buffer = WriteBuffer()
+    spec.write_to(protocol.writer(buffer), deserialized)
 
-@pytest.mark.parametrize('typ, bs', [
-    (ttype.BOOL, []),
-    (ttype.BYTE, []),
-    (ttype.DOUBLE, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
-    (ttype.I16, [0x01]),
-    (ttype.I32, [0x01, 0x02, 0x03]),
-    (ttype.I64, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    assert bs == buffer.value
 
-    (ttype.BINARY, []),
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x01]),
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c]),
 
-    (ttype.STRUCT, []),
-    (ttype.STRUCT, [0x02, 0x01]),
-    (ttype.STRUCT, [0x06, 0x00, 0x01, 0x00, 0x01]),
+@pytest.mark.parametrize('spec, value', [
+    # map = ktype:1 vtype:1 count:4 (key value){count}
+    (smap(si64, sbin), {}),
+    (smap(sbin, slist(sbyte)), {
+        b"a": [1],
+        b"b": [2, 3]
+    }),
 
-    (ttype.MAP, []),
-    (ttype.MAP, [0x02, 0x03]),
-    (ttype.MAP, [0x02, 0x03, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.MAP, [
+    # set = vtype:1 count:4 (value){count)
+    (sset(sbool), set()),
+    (sset(sbool), {True})
+], ids=["map1", "map2", "set1", "set2"])
+def test_reader_and_writer_noorder(spec, value):
+    """Test serialization and deserialization for types
+    that have no guaranteed order."""
+    protocol = BinaryProtocol()
+
+    buffer = WriteBuffer()
+    spec.write_to(protocol.writer(buffer), value)
+    result = spec.read_from(protocol.reader(ReadBuffer(buffer.value)))
+
+    assert result == value
+
+
+@pytest.mark.parametrize('typ, spec, bs', [
+    (ttype.BOOL, sbool, []),
+    (ttype.BYTE, sbyte, []),
+    (ttype.DOUBLE, sdouble, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    (ttype.I16, si16, [0x01]),
+    (ttype.I32, si32, [0x01, 0x02, 0x03]),
+    (ttype.I64, si64, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+
+    (ttype.BINARY, sbin, []),
+    (ttype.BINARY, sbin, [0x00, 0x00, 0x00, 0x01]),
+    (ttype.BINARY, sbin, [0x00, 0x00, 0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c]),
+
+    (ttype.STRUCT, sstruct("1: optional bool p1"), []),
+    (ttype.STRUCT, sstruct("1: optional bool p1"), [0x02, 0x01]),
+    (
+        ttype.STRUCT,
+        sstruct("1: optional i16 p1"),
+        [0x06, 0x00, 0x01, 0x00, 0x01]
+    ),
+
+    (ttype.MAP, smap(si32, sbyte), []),
+    (ttype.MAP, smap(si32, sbyte), [0x02, 0x03]),
+    (ttype.MAP, smap(si32, sbyte), [0x02, 0x03, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.MAP, smap(si32, sbyte), [
         0x02, 0x03,                 # ktype vtype
         0x00, 0x00, 0x00, 0x02,     # len = 2
         0x00, 0x01,                 # (False, 1)
         0x01                        # (True, ?)
     ]),
 
-    (ttype.SET, []),
-    (ttype.SET, [0x02]),
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00]),
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.SET, [
+    (ttype.SET, sset(sbool), []),
+    (ttype.SET, sset(sbool), [0x02]),
+    (ttype.SET, sset(sbool), [0x02, 0x00, 0x00, 0x00]),
+    (ttype.SET, sset(sbool), [0x02, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.SET, sset(sbool), [
         0x02,                    # typ
         0x00, 0x00, 0x00, 0x02,  # len = 2
         0x01,                    # True
     ]),
 
-    (ttype.LIST, []),
-    (ttype.LIST, [0x02]),
-    (ttype.LIST, [0x02, 0x00, 0x00, 0x00]),
-    (ttype.LIST, [0x02, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.LIST, [
+    (ttype.LIST, slist(sbool), []),
+    (ttype.LIST, slist(sbool), [0x02]),
+    (ttype.LIST, slist(sbool), [0x02, 0x00, 0x00, 0x00]),
+    (ttype.LIST, slist(sbool), [0x02, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.LIST, slist(sbool), [
         0x02,                    # typ
         0x00, 0x00, 0x00, 0x02,  # len = 2
+
         0x01,                    # True
     ]),
 ], ids=reader_writer_ids)
-def test_input_too_short(typ, bs):
+def test_input_too_short(typ, spec, bs):
     """Test that EndOfInputError is raised when not enough bytes are
     available."""
 
     protocol = BinaryProtocol()
 
     with pytest.raises(EndOfInputError) as exc_info:
-        protocol.deserialize_value(typ, bytes(bytearray(bs)))
+        s = bytes(bytearray(bs))
+        protocol.deserialize_value(typ, s)
+
+        reader = protocol.reader(ReadBuffer(s))
+        spec.read_from(reader)
 
     assert 'bytes but got' in str(exc_info)
 

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -330,7 +330,6 @@ def test_unrecognized_exception(loads, method, raw, wire_value):
         ('"S_%s_response" received an unrecognized exception' % method)
         in str(exc_info)
     )
-    assert exc_info.value.thrift_response == wire_value
 
 
 def test_args_and_results_know_function_spec(loads):

--- a/tests/util/spec.py
+++ b/tests/util/spec.py
@@ -1,0 +1,29 @@
+from thriftrw.spec.list import ListTypeSpec
+from thriftrw.spec.map import MapTypeSpec
+from thriftrw.spec.struct import StructTypeSpec
+from thriftrw.spec.set import SetTypeSpec
+from thriftrw.idl import Parser
+from thriftrw.compile.scope import Scope
+
+
+parse_struct = Parser(start='struct', silent=True).parse
+
+
+def sstruct(fields=""):
+    """This helper creates a mock spec for sstruct """
+    struct_ast = parse_struct('struct RefStruct { %s }' % fields)
+    spec = StructTypeSpec.compile(struct_ast)
+    spec.link(Scope("test"))
+    return spec
+
+
+def smap(key, value):
+    return MapTypeSpec(key, value)
+
+
+def sset(value):
+    return SetTypeSpec(value)
+
+
+def slist(value):
+    return ListTypeSpec(value)

--- a/thriftrw/_buffer.pxd
+++ b/thriftrw/_buffer.pxd
@@ -33,6 +33,8 @@ cdef class ReadBuffer(object):
 
     cpdef bytes take(self, int count)
 
+    cpdef void skip(self, int count) except *
+
 
 cdef class WriteBuffer(object):
     cdef char* data

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -167,6 +167,23 @@ cdef class ReadBuffer(object):
 
         return result
 
+    cpdef void skip(self, int count) except *:
+        """Skip ``count`` bytes without performing any memory copying.
+
+        :param int count:
+            Number of bytes to read.
+        :raises EndOfInputError:
+            If the number of bytes available in the buffer is less than
+            ``count``.
+        """
+        if count > self.length - self.offset:
+            raise EndOfInputError(
+                'Expected %d bytes but got %d bytes.' %
+                (count, self.available)
+            )
+
+        self.offset += count
+
     property available:
         """Number of bytes available in the buffer."""
 

--- a/thriftrw/_runtime.pyx
+++ b/thriftrw/_runtime.pyx
@@ -25,10 +25,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from libc.stdint cimport int32_t
 
-from thriftrw._buffer cimport WriteBuffer
+from thriftrw._buffer cimport WriteBuffer, ReadBuffer
 from thriftrw.protocol.core cimport (
     Protocol,
     ProtocolWriter,
+    ProtocolReader,
     MessageHeader,
 )
 from thriftrw.wire cimport mtype
@@ -43,9 +44,7 @@ from thriftrw.errors import (
     UnknownExceptionError,
 )
 
-
 cdef class Serializer(object):
-
     def __cinit__(self, Protocol protocol):
         self.protocol = protocol
 
@@ -111,9 +110,7 @@ cdef class Serializer(object):
 
         return buff.value
 
-
 cdef class Deserializer(object):
-
     def __cinit__(self, Protocol protocol):
         self.protocol = protocol
 
@@ -133,8 +130,9 @@ cdef class Deserializer(object):
         return self.loads(obj_cls, s)
 
     cpdef object loads(self, obj_cls, bytes s):
-        cdef Value value = self.protocol.deserialize_value(ttype.STRUCT, s)
-        return obj_cls.type_spec.from_wire(value)
+        cdef ReadBuffer buff = ReadBuffer(s)
+        cdef ProtocolReader reader = self.protocol.reader(buff)
+        return obj_cls.type_spec.read_from(reader)
 
     cpdef Message message(self, service, bytes s):
         """Deserializes a message from the given blob.
@@ -154,42 +152,48 @@ cdef class Deserializer(object):
             If the method name is not recognized or if any other parsing error
             occurs.
         """
-        service_spec = service.service_spec
+        cdef ProtocolReader reader = self.protocol.reader(ReadBuffer(s))
+        cdef Message message
+        cdef object body
 
-        cdef Message message = self.protocol.deserialize_message(s)
+        cdef MessageHeader header = reader.read_message_begin()
 
-        if message.message_type == mtype.EXCEPTION:
+        # Use message header to find a spec for deserializing body.
+
+        if header.type == mtype.EXCEPTION:
             # For EXCEPTION messages, just raise UnknownExceptionError with
             # the struct representation in the message.
-            raise UnknownExceptionError('Received an exception message.', message.body)
+            raise UnknownExceptionError('Received an exception message.', header)
 
-        function_spec = service_spec.lookup(message.name)
+        function_spec = service.service_spec.lookup(header.name)
         if function_spec is None:
             raise ThriftProtocolError(
-                'Unknown method "%s" referenced my message %r'
-                % (message.name, message)
+                'Unknown method "%s" referenced by message %r'
+                % (header.name, header)
             )
 
         if (
-            message.message_type == mtype.CALL or
-            message.message_type == mtype.ONEWAY
+            header.type == mtype.CALL or
+            header.type == mtype.ONEWAY
         ):
-            message.body = function_spec.args_spec.from_wire(message.body)
-        elif message.message_type == mtype.REPLY:
+            body = function_spec.args_spec.read_from(reader)
+        elif header.type == mtype.REPLY:
             if function_spec.oneway:
                 raise ThriftProtocolError(
                     'Function "%s" is a oneway method. '
                     'It cannot receive a REPLY.' % function_spec.name
                 )
 
-            message.body = function_spec.result_spec.from_wire(message.body)
+            body = function_spec.result_spec.read_from(reader)
         else:
             # Unrecognized message type. If this happens, we have a bug
             # because deserialize_message already raises an exception for
             # invalid message IDs.
             raise ValueError(
                 'Unknown message type %d in message %r'
-                % (message.message_type, message)
+                % (header.type, header)
             )
 
-        return message
+        reader.read_message_end()
+
+        return Message(header.name, header.seqid, header.type, body)

--- a/thriftrw/_runtime.pyx
+++ b/thriftrw/_runtime.pyx
@@ -30,7 +30,6 @@ from thriftrw.protocol.core cimport (
     Protocol,
     ProtocolWriter,
     MessageHeader,
-    String,
 )
 from thriftrw.wire cimport mtype
 from thriftrw.wire cimport ttype
@@ -96,13 +95,15 @@ cdef class Serializer(object):
                 'in messages.'
             )
 
+        cdef bytes name
+        if isinstance(function_spec.name, unicode):
+            name = function_spec.name.encode('utf-8')
+        else:
+            name = function_spec.name
+
         cdef WriteBuffer buff = WriteBuffer()
         cdef ProtocolWriter writer = self.protocol.writer(buff)
-        cdef MessageHeader header = MessageHeader(
-            String.from_bytes(function_spec.name),
-            message_type,
-            seqid,
-        )
+        cdef MessageHeader header = MessageHeader(name, message_type, seqid)
 
         writer.write_message_begin(header)
         obj_spec.write_to(writer, obj)

--- a/thriftrw/errors.py
+++ b/thriftrw/errors.py
@@ -65,7 +65,7 @@ class EndOfInputError(ThriftProtocolError):
 class UnknownExceptionError(ThriftError):
     """We parsed an unknown exception in a function response."""
 
-    def __init__(self, message, thrift_response):
+    def __init__(self, message, thrift_response=None):
         super(UnknownExceptionError, self).__init__(message)
         self.thrift_response = thrift_response
 

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -30,7 +30,6 @@ from libc.stdint cimport (
 from .core cimport (
     Protocol,
     ProtocolWriter,
-    String,
     FieldHeader,
     MapHeader,
     SetHeader,

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -27,7 +27,16 @@ from libc.stdint cimport (
     int64_t,
 )
 
-from thriftrw.protocol.core cimport Protocol
+from .core cimport (
+    Protocol,
+    ProtocolWriter,
+    String,
+    FieldHeader,
+    MapHeader,
+    SetHeader,
+    ListHeader,
+    MessageHeader,
+)
 from thriftrw.wire.message cimport Message
 from thriftrw._buffer cimport ReadBuffer, WriteBuffer
 from thriftrw.wire.value cimport (
@@ -96,11 +105,7 @@ cdef class BinaryProtocolReader(object):
     cdef ListValue read_list(self)
 
 
-cdef class BinaryProtocolWriter(ValueVisitor):
+cdef class BinaryProtocolWriter(ProtocolWriter):
     cdef WriteBuffer writer
 
-    cpdef void write(self, Value value)
-
-    cdef _write(self, char* data, int length)
-
-    cdef void write_message(self, Message message) except *
+    cdef void _write(BinaryProtocolWriter self, char* data, int length)

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -30,6 +30,7 @@ from libc.stdint cimport (
 from .core cimport (
     Protocol,
     ProtocolWriter,
+    ProtocolReader,
     FieldHeader,
     MapHeader,
     SetHeader,
@@ -60,7 +61,24 @@ from thriftrw.wire.value cimport (
 cdef class BinaryProtocol(Protocol):
     pass
 
-cdef class BinaryProtocolReader(object):
+cdef class BinaryProtocolReader(ProtocolReader):
+    cdef ReadBuffer reader
+
+    cdef void _read(self, char* data, int count) except *
+    cdef int8_t _byte(self) except *
+    cdef int16_t _i16(self) except *
+    cdef int32_t _i32(self) except *
+    cdef int64_t _i64(self) except *
+    cdef double _double(self) except *
+
+
+cdef class BinaryProtocolWriter(ProtocolWriter):
+    cdef WriteBuffer writer
+
+    cdef void _write(BinaryProtocolWriter self, char* data, int length)
+
+
+cdef class _OldBinaryProtocolReader(object):
     cdef ReadBuffer reader
 
     cdef object _reader(self, int8_t typ)
@@ -102,9 +120,3 @@ cdef class BinaryProtocolReader(object):
     cdef SetValue read_set(self)
 
     cdef ListValue read_list(self)
-
-
-cdef class BinaryProtocolWriter(ProtocolWriter):
-    cdef WriteBuffer writer
-
-    cdef void _write(BinaryProtocolWriter self, char* data, int length)

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -53,7 +53,6 @@ from thriftrw.wire.value cimport (
 from .core cimport (
     Protocol,
     ProtocolWriter,
-    String,
     FieldHeader,
     MapHeader,
     SetHeader,
@@ -362,10 +361,12 @@ cdef class BinaryProtocolWriter(ProtocolWriter):
         value = htobe64(value)
         self._write(<char*>(&value), 8)
 
-    cdef void write_binary(BinaryProtocolWriter self, String s) except *:
+    cdef void write_binary(BinaryProtocolWriter self, bytes value) except *:
         # len:4 str:len
-        self.write_i32(s.length)
-        self._write(s.contents, s.length)
+        cdef int32_t length = <int32_t>len(value)
+        cdef char* contents = value;
+        self.write_i32(length)
+        self._write(contents, length)
 
     cdef void write_field_begin(BinaryProtocolWriter self,
                                 FieldHeader header) except *:

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -53,6 +53,7 @@ from thriftrw.wire.value cimport (
 from .core cimport (
     Protocol,
     ProtocolWriter,
+    ProtocolReader,
     FieldHeader,
     MapHeader,
     SetHeader,
@@ -71,6 +72,8 @@ from ._endian cimport (
 )
 
 
+cdef STRUCT_END_HEADER = FieldHeader(-1, -1)
+
 cdef int8_t STRUCT_END = 0
 
 cdef int32_t VERSION = 1
@@ -85,12 +88,312 @@ cdef int32_t VERSION_MASK = 0x7fff0000
 cdef int32_t TYPE_MASK = 0x000000ff
 
 
-cdef class BinaryProtocolReader(object):
+cdef class BinaryProtocolReader(ProtocolReader):
     """Parser for the binary protocol."""
 
     def __cinit__(self, ReadBuffer reader):
         """Initialize the reader.
 
+        :param reader:
+            File-like object with a ``read(num)`` method which returns
+            *exactly* the requested number of bytes, or all remaining bytes if
+            ``num`` is negative.
+        """
+        self.reader = reader
+
+    cdef void skip(self, int typ) except *:
+        if typ == ttype.BOOL:
+            self.reader.skip(1)
+        elif typ == ttype.BYTE:
+            self.reader.skip(1)
+        elif typ == ttype.DOUBLE:
+            self.reader.skip(8)
+        elif typ == ttype.I16:
+            self.reader.skip(2)
+        elif typ == ttype.I32:
+            self.reader.skip(4)
+        elif typ == ttype.I64:
+            self.reader.skip(8)
+        elif typ == ttype.BINARY:
+            self.skip_binary()
+        elif typ == ttype.STRUCT:
+            self.skip_struct()
+        elif typ == ttype.MAP:
+            self.skip_map()
+        elif typ == ttype.SET:
+            self.skip_set()
+        elif typ == ttype.LIST:
+            self.skip_list()
+
+    cdef void skip_struct(self) except *:
+        header = self.read_field_begin()
+        while header.type != -1:
+            self.skip(header.type)
+            header = self.read_field_begin()
+
+    cdef void skip_map(self) except *:
+        # TODO: This could be optimized to precompute the expected
+        # size for fixed width types
+        cdef MapHeader header = self.read_map_begin()
+        for _ in range(header.size):
+            self.skip(header.ktype)
+            self.skip(header.vtype)
+
+    cdef void skip_list(self) except *:
+        # TODO: This could be optimized to precompute the expected
+        # size for fixed width types
+        cdef ListHeader header = self.read_list_begin()
+        for _ in range(header.size):
+            self.skip(header.type)
+
+    cdef void skip_set(self) except *:
+        # TODO: This could be optimized to precompute the expected
+        # size for fixed width types
+        cdef SetHeader header = self.read_set_begin()
+        for _ in range(header.size):
+            self.skip(header.type)
+
+    cdef void _read(self, char* data, int count) except *:
+        self.reader.read(data, count)
+
+    cdef int8_t _byte(self) except *:
+        cdef char c
+        self._read(&c, 1)
+        return <int8_t>c
+
+    cdef int16_t _i16(self) except *:
+        cdef char data[2]
+        self._read(data, 2)
+        return be16toh((<int16_t*>data)[0])
+
+    cdef int32_t _i32(self) except *:
+        cdef char data[4]
+        self._read(data, 4)
+        return be32toh((<int32_t*>data)[0])
+
+    cdef int64_t _i64(self) except *:
+        cdef char data[8]
+        self._read(data, 8)
+        return be64toh((<int64_t*>data)[0])
+
+    cdef double _double(self) except *:
+        cdef int64_t value = self._i64()
+        return (<double*>(&value))[0]
+
+    cdef bint read_bool(self) except *:
+        """Reads a boolean."""
+        return self._byte() == 1
+
+    cdef int8_t read_byte(self) except *:
+        """Reads a byte."""
+        return self._byte()
+
+    cdef double read_double(self) except *:
+        """Reads a double."""
+        return self._double()
+
+    cdef int16_t read_i16(self) except *:
+        """Reads a 16-bit integer."""
+        return self._i16()
+
+    cdef int32_t read_i32(self) except *:
+        """Reads a 32-bit integer."""
+        return self._i32()
+
+    cdef int64_t read_i64(self) except *:
+        """Reads a 64-bit integer."""
+        return self._i64()
+
+    cdef bytes read_binary(self):
+        """Reads a binary blob."""
+        cdef int32_t length = self._i32()
+        return self.reader.take(length)
+
+    cdef void skip_binary(self) except *:
+        cdef int32_t length = self._i32()
+        self.reader.skip(length)
+
+    cdef FieldHeader read_field_begin(self):
+        cdef int8_t field_type = self._byte()
+        if field_type == STRUCT_END:
+            return STRUCT_END_HEADER
+
+        cdef int16_t field_id = self._i16()
+
+        return FieldHeader(field_type, field_id)
+
+    cdef MapHeader read_map_begin(self):
+        cdef int8_t key_ttype = self._byte()
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        return MapHeader(key_ttype, value_ttype, length)
+
+    cdef SetHeader read_set_begin(self):
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        return SetHeader(value_ttype, length)
+
+    cdef ListHeader read_list_begin(self):
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        return ListHeader(value_ttype, length)
+
+    cdef MessageHeader read_message_begin(self):
+        cdef int8_t typ
+        cdef int16_t version
+        cdef int32_t size
+        cdef int32_t seqid
+        cdef bytes name
+
+        size = self._i32()
+        # TODO with cython, some of the Python-specific hacks around bit
+        # twiddling can be skipped.
+        if size < 0:
+            # strict version:
+            #
+            #     versionAndType:4 name~4 seqid:4 payload
+            version = (size & VERSION_MASK) >> 16
+            if version != VERSION:
+                raise ThriftProtocolError(
+                    'Unsupported version "%r"' % version
+                )
+            typ = size & TYPE_MASK
+            size = self._i32()
+            name = self.reader.take(size)
+        else:
+            # non-strict version:
+            #
+            #     name:4 type:1 seqid:4 payload
+            name = self.reader.take(size)
+            typ = self._byte()
+
+        seqid = self._i32()
+        return MessageHeader(name, typ, seqid)
+
+
+cdef class BinaryProtocolWriter(ProtocolWriter):
+    """Serializes values using the Thrift Binary protocol."""
+
+    def __cinit__(BinaryProtocolWriter self, WriteBuffer writer):
+        """Initialize the writer.
+
+        :param writer:
+            WriteBuffer to which requests will be written.
+        """
+        self.writer = writer
+
+    cdef void _write(BinaryProtocolWriter self, char* data, int length):
+        self.writer.write(data, length)
+
+    cdef void write_bool(self, bint value) except *:  # bool:1
+        self.write_byte(value)
+
+    cdef void write_byte(BinaryProtocolWriter self, int8_t value) except *:
+        # byte:1
+        cdef char c = <char>value
+        self._write(&c, 1)
+
+    cdef void write_double(self, double value) except *:  # double:8
+        # If confused:
+        #
+        #   <typ*>(&value)[0]
+        #
+        # Is just "interpret the in-memory representation of value as typ"
+        self.write_i64((<int64_t*>(&value))[0])
+
+    cdef void write_i16(BinaryProtocolWriter self, int16_t value) except *:
+        # i16:2
+        value = htobe16(value)
+        self._write(<char*>(&value), 2)
+
+    cdef void write_i32(BinaryProtocolWriter self, int32_t value) except *:
+        # i32:4
+        value = htobe32(value)
+        self._write(<char*>(&value), 4)
+
+    cdef void write_i64(BinaryProtocolWriter self, int64_t value) except *:
+        # i64:8
+        value = htobe64(value)
+        self._write(<char*>(&value), 8)
+
+    cdef void write_binary(BinaryProtocolWriter self, bytes value) except *:
+        # len:4 str:len
+        cdef int32_t length = <int32_t>len(value)
+        cdef char* contents = value;
+        self.write_i32(length)
+        self._write(contents, length)
+
+    cdef void write_field_begin(BinaryProtocolWriter self,
+                                FieldHeader header) except *:
+        # type:1 id:2
+        self.write_byte(header.type)
+        self.write_i16(header.id)
+
+    cdef void write_struct_end(BinaryProtocolWriter self) except *:
+        self.write_byte(STRUCT_END)
+
+    cdef void write_map_begin(BinaryProtocolWriter self,
+                              MapHeader header) except *:
+        # key_type:1 value_type:1 count:4
+        self.write_byte(header.ktype)
+        self.write_byte(header.vtype)
+        self.write_i32(header.size)
+
+    cdef void write_set_begin(BinaryProtocolWriter self,
+                              SetHeader header) except *:
+        # value_type:1 count:4
+        self.write_byte(header.type)
+        self.write_i32(header.size)
+
+    cdef void write_list_begin(BinaryProtocolWriter self,
+                               ListHeader header) except *:
+        # value_type:1 count:4
+        self.write_byte(header.type)
+        self.write_i32(header.size)
+
+    cdef void write_message_begin(BinaryProtocolWriter self,
+                                  MessageHeader message) except *:
+        self.write_binary(message.name)
+        self.write_byte(message.type)
+        self.write_i32(message.seqid)
+
+
+cdef class BinaryProtocol(Protocol):
+    """Implements the Thrift binary protocol."""
+
+    cpdef ProtocolReader reader(self, ReadBuffer buff):
+        return BinaryProtocolReader(buff)
+
+    cpdef ProtocolWriter writer(self, WriteBuffer buff):
+        return BinaryProtocolWriter(buff)
+
+    cpdef Message deserialize_message(self, bytes s):
+        cdef ReadBuffer buff = ReadBuffer(s)
+        return _OldBinaryProtocolReader(buff).read_message()
+
+    cpdef Value deserialize_value(self, int typ, bytes s):
+        cdef ReadBuffer buff = ReadBuffer(s)
+        return _OldBinaryProtocolReader(buff).read(typ)
+
+
+__all__ = ['BinaryProtocol']
+
+
+cdef class _OldBinaryProtocolReader(object):
+    """Old version of BinaryProtocolReader that returned Value representations.
+
+    Deserialization was refactored in 1.4 to avoid this step as an optimization.
+    This class exists to provide support for backwards compatibility but will
+    be removed in a later version.
+
+    .. deprecated:: 1.4
+    """
+
+    def __cinit__(self, ReadBuffer reader):
+        """Initialize the reader.
         :param reader:
             File-like object with a ``read(num)`` method which returns
             *exactly* the requested number of bytes, or all remaining bytes if
@@ -314,107 +617,3 @@ cdef class BinaryProtocolReader(object):
             value_ttype=value_ttype,
             values=values
         )
-
-
-cdef class BinaryProtocolWriter(ProtocolWriter):
-    """Serializes values using the Thrift Binary protocol."""
-
-    def __cinit__(BinaryProtocolWriter self, WriteBuffer writer):
-        """Initialize the writer.
-
-        :param writer:
-            WriteBuffer to which requests will be written.
-        """
-        self.writer = writer
-
-    cdef void _write(BinaryProtocolWriter self, char* data, int length):
-        self.writer.write(data, length)
-
-    cdef void write_bool(self, bint value) except *:  # bool:1
-        self.write_byte(value)
-
-    cdef void write_byte(BinaryProtocolWriter self, int8_t value) except *:
-        # byte:1
-        cdef char c = <char>value
-        self._write(&c, 1)
-
-    cdef void write_double(self, double value) except *:  # double:8
-        # If confused:
-        #
-        #   <typ*>(&value)[0]
-        #
-        # Is just "interpret the in-memory representation of value as typ"
-        self.write_i64((<int64_t*>(&value))[0])
-
-    cdef void write_i16(BinaryProtocolWriter self, int16_t value) except *:
-        # i16:2
-        value = htobe16(value)
-        self._write(<char*>(&value), 2)
-
-    cdef void write_i32(BinaryProtocolWriter self, int32_t value) except *:
-        # i32:4
-        value = htobe32(value)
-        self._write(<char*>(&value), 4)
-
-    cdef void write_i64(BinaryProtocolWriter self, int64_t value) except *:
-        # i64:8
-        value = htobe64(value)
-        self._write(<char*>(&value), 8)
-
-    cdef void write_binary(BinaryProtocolWriter self, bytes value) except *:
-        # len:4 str:len
-        cdef int32_t length = <int32_t>len(value)
-        cdef char* contents = value;
-        self.write_i32(length)
-        self._write(contents, length)
-
-    cdef void write_field_begin(BinaryProtocolWriter self,
-                                FieldHeader header) except *:
-        # type:1 id:2
-        self.write_byte(header.type)
-        self.write_i16(header.id)
-
-    cdef void write_struct_end(BinaryProtocolWriter self) except *:
-        self.write_byte(STRUCT_END)
-
-    cdef void write_map_begin(BinaryProtocolWriter self,
-                              MapHeader header) except *:
-        # key_type:1 value_type:1 count:4
-        self.write_byte(header.ktype)
-        self.write_byte(header.vtype)
-        self.write_i32(header.size)
-
-    cdef void write_set_begin(BinaryProtocolWriter self,
-                              SetHeader header) except *:
-        # value_type:1 count:4
-        self.write_byte(header.type)
-        self.write_i32(header.size)
-
-    cdef void write_list_begin(BinaryProtocolWriter self,
-                               ListHeader header) except *:
-        # value_type:1 count:4
-        self.write_byte(header.type)
-        self.write_i32(header.size)
-
-    cdef void write_message_begin(BinaryProtocolWriter self,
-                                  MessageHeader message) except *:
-        self.write_binary(message.name)
-        self.write_byte(message.type)
-        self.write_i32(message.seqid)
-
-
-cdef class BinaryProtocol(Protocol):
-    """Implements the Thrift binary protocol."""
-
-    cpdef ProtocolWriter writer(self, WriteBuffer buff):
-        return BinaryProtocolWriter(buff)
-
-    cpdef Message deserialize_message(self, bytes s):
-        cdef ReadBuffer buff = ReadBuffer(s)
-        return BinaryProtocolReader(buff).read_message()
-
-    cpdef Value deserialize_value(self, int typ, bytes s):
-        cdef ReadBuffer buff = ReadBuffer(s)
-        return BinaryProtocolReader(buff).read(typ)
-
-__all__ = ['BinaryProtocol']

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -30,7 +30,7 @@ from libc.stdint cimport (
 from thriftrw.wire cimport ttype
 from thriftrw.wire.value cimport Value, ValueVisitor
 from thriftrw.wire.message cimport Message
-from thriftrw._buffer cimport WriteBuffer
+from thriftrw._buffer cimport WriteBuffer, ReadBuffer
 
 
 cdef class FieldHeader(object):
@@ -98,8 +98,55 @@ cdef class ProtocolWriter(object):
     cdef void write_message_end(self) except *
 
 
+cdef class ProtocolReader:
+
+    # Skip
+
+    cdef void skip(self, int typ) except *
+    cdef void skip_binary(self) except *
+    cdef void skip_map(self) except *
+    cdef void skip_list(self) except *
+    cdef void skip_set(self) except *
+    cdef void skip_struct(self) except *
+
+    # Primitives
+
+    cdef bint read_bool(self) except *
+    cdef int8_t read_byte(self) except *
+    cdef double read_double(self) except *
+    cdef int16_t read_i16(self) except *
+    cdef int32_t read_i32(self) except *
+    cdef int64_t read_i64(self) except *
+    cdef bytes read_binary(self)
+
+    # Structs
+
+    cdef void read_struct_begin(self) except *
+    cdef FieldHeader read_field_begin(self)
+    cdef void read_field_end(self) except *
+    cdef void read_struct_end(self) except *
+
+    # Containers
+
+    cdef MapHeader read_map_begin(self)
+    cdef void read_map_end(self) except *
+
+    cdef SetHeader read_set_begin(self)
+    cdef void read_set_end(self) except *
+
+    cdef ListHeader read_list_begin(self)
+    cdef void read_list_end(self) except *
+
+    # Messages
+
+    cdef MessageHeader read_message_begin(self)
+    cdef void read_message_end(self) except *
+
+
 cdef class Protocol(object):
     cpdef ProtocolWriter writer(self, WriteBuffer buff)
+
+    cpdef ProtocolReader reader(self, ReadBuffer buff)
 
     cpdef bytes serialize_value(self, Value value)
 

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -33,19 +33,6 @@ from thriftrw.wire.message cimport Message
 from thriftrw._buffer cimport WriteBuffer
 
 
-cdef class String(object):
-    cdef char* contents
-    cdef int32_t length
-    cdef bytes _data
-    # If this was created using from_bytes, we need to hold the reference to
-    # the original PyObject to ensure it doesn't get GCed.
-
-    cdef bytes as_bytes(self)
-
-    @staticmethod
-    cdef String from_bytes(bytes s)
-
-
 cdef class FieldHeader(object):
     cdef readonly int8_t type
     cdef readonly int16_t id
@@ -68,7 +55,7 @@ cdef class ListHeader(object):
 
 
 cdef class MessageHeader(object):
-    cdef readonly String name
+    cdef readonly bytes name
     cdef readonly int8_t type
     cdef readonly int32_t seqid
 
@@ -85,7 +72,7 @@ cdef class ProtocolWriter(object):
     cdef void write_i16(self, int16_t value) except *
     cdef void write_i32(self, int32_t value) except *
     cdef void write_i64(self, int64_t value) except *
-    cdef void write_binary(self, String value) except *
+    cdef void write_binary(self, bytes value) except *
 
     # Structs
 

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -71,6 +71,14 @@ cdef class MessageHeader(object):
         self.type = type
         self.seqid = seqid
 
+    def __str__(self):
+        return 'MessageHeader(%r, %r, %r)' % (
+            self.name, self.seqid, ttype.name_of(self.type)
+        )
+
+    def __repr__(self):
+        return str(self)
+
 
 cdef class ProtocolWriter(object):
 
@@ -98,6 +106,56 @@ cdef class ProtocolWriter(object):
     cdef void write_message_end(self) except *: pass
 
 
+cdef class ProtocolReader:
+
+    # Skip
+
+    cdef void skip(self, int typ) except *: pass
+    cdef void skip_binary(self) except *: pass
+    cdef void skip_map(self) except *: pass
+    cdef void skip_list(self) except *: pass
+    cdef void skip_set(self) except *: pass
+    cdef void skip_struct(self) except *: pass
+
+    # Primitives
+
+    cdef bint read_bool(self) except *: pass
+    cdef int8_t read_byte(self) except *: pass
+    cdef double read_double(self) except *: pass
+    cdef int16_t read_i16(self) except *: pass
+    cdef int32_t read_i32(self) except *: pass
+    cdef int64_t read_i64(self) except *: pass
+    cdef bytes read_binary(self): pass
+
+    # Structs
+
+    cdef void read_struct_begin(self) except *: pass
+    cdef FieldHeader read_field_begin(self):
+        """Parse the next three bytes as a FieldHeader object.
+
+        :return: FieldHeader with type and id set to -1 if a struct end is found.
+        """
+        pass
+    cdef void read_field_end(self) except *: pass
+    cdef void read_struct_end(self) except *: pass
+
+    # Containers
+
+    cdef MapHeader read_map_begin(self): pass
+    cdef void read_map_end(self) except *: pass
+
+    cdef SetHeader read_set_begin(self): pass
+    cdef void read_set_end(self) except *: pass
+
+    cdef ListHeader read_list_begin(self): pass
+    cdef void read_list_end(self) except *: pass
+
+    # Messages
+
+    cdef MessageHeader read_message_begin(self): pass
+    cdef void read_message_end(self) except *: pass
+
+
 cdef class Protocol(object):
     """Base class for all protocol implementations.
 
@@ -106,6 +164,9 @@ cdef class Protocol(object):
         Removed ``dumps`` and ``loads`` methods and added
         ``serialize_message`` and ``deserialize_message``.
     """
+
+    cpdef ProtocolReader reader(self, ReadBuffer buff):
+        raise NotImplementedError
 
     cpdef ProtocolWriter writer(self, WriteBuffer buff):
         raise NotImplementedError

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -20,12 +20,101 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+)
+
 from thriftrw.wire cimport ttype
-from thriftrw.wire.value cimport Value
+from thriftrw.wire.value cimport Value, ValueVisitor
 from thriftrw.wire.message cimport Message
 
 
 __all__ = ['Protocol']
+
+
+cdef class String(object):
+
+    def __cinit__(String self, char* contents, int32_t length,
+                  bytes _data=None):
+        self.contents = contents
+        self.length = length
+        self._data = _data
+
+    cdef bytes as_bytes(String self):
+        return self.contents[:self.length]
+
+    @staticmethod
+    cdef String from_bytes(bytes s):
+        cdef char* contents = s
+        cdef int32_t length = len(s)
+        return String(contents, length, s)
+
+
+cdef class FieldHeader(object):
+
+    def __cinit__(FieldHeader self, int8_t type, int16_t id):
+        self.type = type
+        self.id = id
+
+
+cdef class MapHeader(object):
+
+    def __cinit__(MapHeader self, int8_t ktype, int8_t vtype, int32_t size):
+        self.ktype = ktype
+        self.vtype = vtype
+        self.size = size
+
+
+cdef class SetHeader(object):
+
+    def __cinit__(SetHeader self, int8_t type, int32_t size):
+        self.type = type
+        self.size = size
+
+
+cdef class ListHeader(object):
+
+    def __cinit__(ListHeader self, int8_t type, int32_t size):
+        self.type = type
+        self.size = size
+
+
+cdef class MessageHeader(object):
+
+    def __cinit__(MessageHeader self, String name, int8_t type,
+                  int32_t seqid):
+        self.name = name
+        self.type = type
+        self.seqid = seqid
+
+
+cdef class ProtocolWriter(object):
+
+    cdef void write_value(self, Value value) except *:
+        value.apply(_ValueWriter(self))
+
+    cdef void write_bool(self, bint value) except *: pass
+    cdef void write_byte(self, int8_t value) except *: pass
+    cdef void write_double(self, double value) except *: pass
+    cdef void write_i16(self, int16_t value) except *: pass
+    cdef void write_i32(self, int32_t value) except *: pass
+    cdef void write_i64(self, int64_t value) except *: pass
+    cdef void write_binary(self, String value) except *: pass
+    cdef void write_struct_begin(self) except *: pass
+    cdef void write_field_begin(self, FieldHeader header) except *: pass
+    cdef void write_field_end(self) except *: pass
+    cdef void write_struct_end(self) except *: pass
+    cdef void write_map_begin(self, MapHeader header) except *: pass
+    cdef void write_map_end(self) except *: pass
+    cdef void write_set_begin(self, SetHeader header) except *: pass
+    cdef void write_set_end(self) except *: pass
+    cdef void write_list_begin(self, ListHeader header) except *: pass
+    cdef void write_list_end(self) except *: pass
+    cdef void write_message_begin(self, MessageHeader header) except *: pass
+    cdef void write_message_end(self) except *: pass
 
 
 cdef class Protocol(object):
@@ -37,6 +126,9 @@ cdef class Protocol(object):
         ``serialize_message`` and ``deserialize_message``.
     """
 
+    cpdef ProtocolWriter writer(self, WriteBuffer buff):
+        raise NotImplementedError
+
     cpdef bytes serialize_value(self, Value value):
         """Serialize the given ``Value``.
 
@@ -45,6 +137,10 @@ cdef class Protocol(object):
         :returns:
             Serialized value.
         """
+        cdef WriteBuffer buff = WriteBuffer()
+        cdef ProtocolWriter writer = self.writer(buff)
+        writer.write_value(value)
+        return buff.value
 
     cpdef Value deserialize_value(self, int typ, bytes s):
         """Parse a ``Value`` of the given type.
@@ -69,6 +165,19 @@ cdef class Protocol(object):
         :returns:
             Serialized message.
         """
+        cdef WriteBuffer buff = WriteBuffer()
+        cdef ProtocolWriter writer = self.writer(buff)
+        cdef MessageHeader header = MessageHeader(
+            String.from_bytes(message.name),
+            message.message_type,
+            message.seqid,
+        )
+
+        writer.write_message_begin(header)
+        writer.write_value(message.body)
+        writer.write_message_end()
+
+        return buff.value
 
     cpdef Message deserialize_message(self, bytes s):
         """Deserialize a ``Message``.
@@ -79,3 +188,60 @@ cdef class Protocol(object):
             Parsed :py:class:`~thriftrw.wire.Message` containing a
             :py:class:`~thriftrw.wire.Value` in its body.
         """
+
+cdef class _ValueWriter(ValueVisitor):
+
+    def __cinit__(_ValueWriter self, ProtocolWriter writer):
+        self.writer = writer
+
+    cdef object visit_bool(self, bint value):
+        self.writer.write_bool(value)
+
+    cdef object visit_byte(self, int8_t value):
+        self.writer.write_byte(value)
+
+    cdef object visit_double(self, double value):
+        self.writer.write_double(value)
+
+    cdef object visit_i16(self, int16_t value):
+        self.writer.write_i16(value)
+
+    cdef object visit_i32(self, int32_t value):
+        self.writer.write_i32(value)
+
+    cdef object visit_i64(self, int64_t value):
+        self.writer.write_i64(value)
+
+    cdef object visit_binary(self, bytes value):
+        self.writer.write_binary(String.from_bytes(value))
+
+    cdef object visit_struct(self, list fields):
+        self.writer.write_struct_begin()
+        for f in fields:
+            self.writer.write_field_begin(FieldHeader(f.ttype, f.id))
+            f.value.apply(self)
+            self.writer.write_field_end()
+        self.writer.write_struct_end()
+
+    cdef object visit_map(self, int8_t key_ttype, int8_t value_ttype,
+                          list pairs):
+        cdef MapHeader header = MapHeader(key_ttype, value_ttype, len(pairs))
+        self.writer.write_map_begin(header)
+        for item in pairs:
+            item.key.apply(self)
+            item.value.apply(self)
+        self.writer.write_map_end()
+
+    cdef object visit_set(self, int8_t value_ttype, list values):
+        cdef SetHeader header = SetHeader(value_ttype, len(values))
+        self.writer.write_set_begin(header)
+        for value in values:
+            value.apply(self)
+        self.writer.write_set_end()
+
+    cdef object visit_list(self, int8_t value_ttype, list values):
+        cdef ListHeader header = ListHeader(value_ttype, len(values))
+        self.writer.write_list_begin(header)
+        for value in values:
+            value.apply(self)
+        self.writer.write_list_end()

--- a/thriftrw/spec/base.pxd
+++ b/thriftrw/spec/base.pxd
@@ -21,13 +21,16 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
-
+from thriftrw.protocol.core cimport ProtocolWriter
 
 cdef class TypeSpec(object):
 
     cpdef Value to_wire(TypeSpec self, object value)
 
     cpdef object from_wire(TypeSpec self, Value wire_value)
+
+    cpdef void write_to(TypeSpec self, ProtocolWriter writer,
+                        object value) except *
 
     cpdef TypeSpec link(self, scope)
 

--- a/thriftrw/spec/base.pxd
+++ b/thriftrw/spec/base.pxd
@@ -21,13 +21,15 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 
 cdef class TypeSpec(object):
 
     cpdef Value to_wire(TypeSpec self, object value)
 
     cpdef object from_wire(TypeSpec self, Value wire_value)
+
+    cpdef object read_from(TypeSpec self, ProtocolReader reader)
 
     cpdef void write_to(TypeSpec self, ProtocolWriter writer,
                         object value) except *

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
+from thriftrw.protocol.core cimport ProtocolWriter
 
 __all__ = ['TypeSpec']
 
@@ -57,6 +58,10 @@ cdef class TypeSpec(object):
 
         def __get__(self):
             raise NotImplementedError
+
+    cpdef void write_to(TypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_value(self.to_wire(value))
 
     cpdef Value to_wire(TypeSpec self, object value):
         """Converts the given value into a :py:class:`thriftrw.wire.Value`

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -21,12 +21,12 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 
 __all__ = ['TypeSpec']
 
 
-cdef class TypeSpec(object):
+cdef class TypeSpec:
     """Base class for classes representing TypeSpecs.
 
     A TypeSpec knows how to convert values of the corresponding type to and
@@ -59,8 +59,13 @@ cdef class TypeSpec(object):
         def __get__(self):
             raise NotImplementedError
 
+    cpdef object read_from(TypeSpec self, ProtocolReader reader):
+        """Read a primitive value of this type from :py:class:`thriftrw.protocol.ProtocolReader`."""
+        raise NotImplementedError
+
     cpdef void write_to(TypeSpec self, ProtocolWriter writer,
                         object value) except *:
+        """Writes a value directly to :py:class:`thriftrw.protocol.ProtocolWriter`."""
         writer.write_value(self.to_wire(value))
 
     cpdef Value to_wire(TypeSpec self, object value):

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -25,6 +25,7 @@ from collections import defaultdict
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport I32Value, Value
+from thriftrw.protocol.core cimport ProtocolWriter
 from .base cimport TypeSpec
 from . cimport check
 
@@ -144,6 +145,10 @@ cdef class EnumTypeSpec(TypeSpec):
     cpdef object from_wire(self, Value wire_value):
         check.type_code_matches(self, wire_value)
         return wire_value.value
+
+    cpdef void write_to(EnumTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_i32(value)
 
     cpdef object from_primitive(self, object prim_value):
         return prim_value

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -25,7 +25,7 @@ from collections import defaultdict
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport I32Value, Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 from .base cimport TypeSpec
 from . cimport check
 
@@ -135,6 +135,9 @@ cdef class EnumTypeSpec(TypeSpec):
             self.linked = True
             self.surface = enum_cls(self, scope)
         return self
+
+    cpdef object read_from(EnumTypeSpec self, ProtocolReader reader):
+        return reader.read_i32()
 
     cpdef Value to_wire(self, object value):
         return I32Value(value)

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -85,7 +85,7 @@ cdef class FieldSpec(object):
         return self
 
     @property
-    def ttype_code(self):
+    def ttype_code(FieldSpec self):
         return self.spec.ttype_code
 
     @classmethod

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -26,6 +26,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport ListValue
 from thriftrw.wire.value cimport Value
+from thriftrw.protocol.core cimport ListHeader, ProtocolWriter
 
 __all__ = ['ListTypeSpec']
 
@@ -68,6 +69,14 @@ cdef class ListTypeSpec(TypeSpec):
 
     cpdef object to_primitive(ListTypeSpec self, object value):
         return [self.vspec.to_primitive(x) for x in value]
+
+    cpdef void write_to(ListTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        cdef ListHeader header = ListHeader(self.vspec.ttype_code, len(value))
+        writer.write_list_begin(header)
+        for v in value:
+            self.vspec.write_to(writer, v)
+        writer.write_list_end()
 
     cpdef object from_wire(ListTypeSpec self, Value wire_value):
         check.type_code_matches(self, wire_value)

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -26,7 +26,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport ListValue
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ListHeader, ProtocolWriter
+from thriftrw.protocol.core cimport ListHeader, ProtocolWriter, ProtocolReader
 
 __all__ = ['ListTypeSpec']
 
@@ -60,6 +60,15 @@ cdef class ListTypeSpec(TypeSpec):
     @property
     def name(self):
         return 'list<%s>' % self.vspec.name
+
+    cpdef object read_from(ListTypeSpec self, ProtocolReader reader):
+        cdef ListHeader header = reader.read_list_begin()
+        cdef list output = []
+        for i in range(header.size):
+            output.append(self.vspec.read_from(reader))
+
+        reader.read_list_end()
+        return output
 
     cpdef Value to_wire(ListTypeSpec self, object value):
         return ListValue(

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -89,7 +89,7 @@ cdef class MapTypeSpec(TypeSpec):
             self.kspec.ttype_code, self.vspec.ttype_code, len(value)
         )
         writer.write_map_begin(header)
-        for k, v in value.iteritems():
+        for k, v in value.items():
             self.kspec.write_to(writer, k)
             self.vspec.write_to(writer, v)
         writer.write_map_end()

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -25,7 +25,7 @@ from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport MapItem, MapValue, Value
-from thriftrw.protocol.core cimport MapHeader, ProtocolWriter
+from thriftrw.protocol.core cimport MapHeader, ProtocolWriter, ProtocolReader
 
 __all__ = ['MapTypeSpec']
 
@@ -82,6 +82,15 @@ cdef class MapTypeSpec(TypeSpec):
             self.kspec.to_primitive(k): self.vspec.to_primitive(v)
             for k, v in value.items()
         }
+
+    cpdef object read_from(MapTypeSpec self, ProtocolReader reader):
+        cdef MapHeader header = reader.read_map_begin()
+        cdef dict output = {
+            self.kspec.read_from(reader): self.vspec.read_from(reader)
+            for i in range(header.size)
+        }
+        reader.read_map_end()
+        return output
 
     cpdef void write_to(MapTypeSpec self, ProtocolWriter writer,
                         object value) except *:

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -25,6 +25,7 @@ from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport MapItem, MapValue, Value
+from thriftrw.protocol.core cimport MapHeader, ProtocolWriter
 
 __all__ = ['MapTypeSpec']
 
@@ -81,6 +82,17 @@ cdef class MapTypeSpec(TypeSpec):
             self.kspec.to_primitive(k): self.vspec.to_primitive(v)
             for k, v in value.items()
         }
+
+    cpdef void write_to(MapTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        cdef MapHeader header = MapHeader(
+            self.kspec.ttype_code, self.vspec.ttype_code, len(value)
+        )
+        writer.write_map_begin(header)
+        for k, v in value.iteritems():
+            self.kspec.write_to(writer, k)
+            self.vspec.write_to(writer, v)
+        writer.write_map_end()
 
     cpdef object from_wire(MapTypeSpec self, Value wire_value):
         check.type_code_matches(self, wire_value)

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -25,7 +25,7 @@ import decimal
 import fractions
 
 from thriftrw.wire cimport ttype
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 from thriftrw.wire.value cimport (
     Value,
     BoolValue,
@@ -124,6 +124,8 @@ cdef class _TextualTypeSpec(TypeSpec):
 
     cpdef void write_to(_TextualTypeSpec self, ProtocolWriter writer,
                         object value) except *:
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
         writer.write_binary(bytes(value))
 
     cpdef void validate(_TextualTypeSpec self, object instance) except *:
@@ -138,6 +140,10 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
 
     name = str('string')
     surface = unicode
+
+    cpdef object read_from(_TextTypeSpec self, ProtocolReader reader):
+        # TODO: Is this right?
+        return reader.read_binary().decode('utf-8')
 
     cpdef object to_primitive(_TextTypeSpec self, object value):
         if isinstance(value, bytes):
@@ -165,6 +171,9 @@ cdef class _BinaryTypeSpec(_TextualTypeSpec):
     name = str('binary')
     surface = bytes
 
+    cpdef object read_from(_BinaryTypeSpec self, ProtocolReader reader):
+        return reader.read_binary()
+
     cpdef object to_primitive(_BinaryTypeSpec self, object value):
         if isinstance(value, unicode):
             value = value.encode('utf-8')
@@ -191,6 +200,9 @@ cdef class _BoolTypeSpec(TypeSpec):
     name = str('bool')
     surface = bool
     ttype_code = ttype.BOOL
+
+    cpdef object read_from(_BoolTypeSpec self, ProtocolReader reader):
+        return reader.read_bool()
 
     cpdef Value to_wire(_BoolTypeSpec self, object value):
         return BoolValue(bool(value))
@@ -256,6 +268,9 @@ cdef class _ByteTypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_byte(value)
 
+    cpdef object read_from(_ByteTypeSpec self, ProtocolReader reader):
+        return reader.read_byte()
+
 ByteTypeSpec = _ByteTypeSpec()
 
 cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
@@ -270,6 +285,9 @@ cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
     cpdef void write_to(_DoubleTypeSpec self, ProtocolWriter writer,
                         object value) except *:
         writer.write_double(value)
+
+    cpdef object read_from(_DoubleTypeSpec self, ProtocolReader reader):
+        return reader.read_double()
 
 DoubleTypeSpec = _DoubleTypeSpec()
 
@@ -287,6 +305,9 @@ cdef class _I16TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i16(value)
 
+    cpdef object read_from(_I16TypeSpec self, ProtocolReader reader):
+        return reader.read_i16()
+
 I16TypeSpec = _I16TypeSpec()
 
 cdef class _I32TypeSpec(PrimitiveTypeSpec):
@@ -303,6 +324,9 @@ cdef class _I32TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i32(value)
 
+    cpdef object read_from(_I32TypeSpec self, ProtocolReader reader):
+        return reader.read_i32()
+
 I32TypeSpec = _I32TypeSpec()
 
 cdef class _I64TypeSpec(PrimitiveTypeSpec):
@@ -318,6 +342,9 @@ cdef class _I64TypeSpec(PrimitiveTypeSpec):
     cpdef void write_to(_I64TypeSpec self, ProtocolWriter writer,
                         object value) except *:
         writer.write_i64(value)
+
+    cpdef object read_from(_I64TypeSpec self, ProtocolReader reader):
+        return reader.read_i64()
 
 I64TypeSpec = _I64TypeSpec()
 

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -25,6 +25,7 @@ import decimal
 import fractions
 
 from thriftrw.wire cimport ttype
+from thriftrw.protocol.core cimport ProtocolWriter
 from thriftrw.wire.value cimport (
     Value,
     BoolValue,
@@ -52,43 +53,24 @@ __all__ = [
 
 
 cdef class PrimitiveTypeSpec(TypeSpec):
-    """TypeSpec for primitive types."""
+    """TypeSpec for primitive types.
 
-    def __init__(
-        self,
-        name,
-        code,
-        value_cls,
-        surface,
-        cast=None,
-        validate_extra=None
-    ):
-        """
-        :param name:
-            Name of the primitive type
-        :param code:
-            TType code used by this primitive
-        :param value_cls:
-            Constructor for wire value types
-        :param surface:
-            Values passed through this spec must be instances of this class or
-            an exception will be raised
-        :param cast:
-            If provided, this is used to cast values into a standard shape
-            before passing them to ``value_cls``
-        :param validate_extra:
-            If provided, this is used to validate values beyond checking that
-            they have the correct type.
-        """
-        self.name = str(name)
-        self.code = code
-        self.value_cls = value_cls
-        self.surface = surface
-        self.validate_extra = validate_extra
-
-        if cast is None:
-            cast = (lambda x: x)
-        self.cast = cast
+    :param name:
+        Name of the primitive type
+    :param code:
+        TType code used by this primitive
+    :param value_cls:
+        Constructor for wire value types
+    :param surface:
+        Values passed through this spec must be instances of this class or
+        an exception will be raised
+    :param cast:
+        If provided, this is used to cast values into a standard shape
+        before passing them to ``value_cls``
+    :param validate_extra:
+        If provided, this is used to validate values beyond checking that
+        they have the correct type.
+    """
 
     @property
     def ttype_code(self):
@@ -139,6 +121,10 @@ cdef class _TextualTypeSpec(TypeSpec):
         if isinstance(value, unicode):
             value = value.encode('utf-8')
         return BinaryValue(value)
+
+    cpdef void write_to(_TextualTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_binary(bytes(value))
 
     cpdef void validate(_TextualTypeSpec self, object instance) except *:
         if not isinstance(instance, (bytes, unicode)):
@@ -219,6 +205,10 @@ cdef class _BoolTypeSpec(TypeSpec):
     cpdef object from_primitive(_BoolTypeSpec self, object prim_value):
         return bool(prim_value)
 
+    cpdef void write_to(_BoolTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_bool(value)
+
     cpdef TypeSpec link(self, scope):
         return self
 
@@ -252,29 +242,84 @@ _FLOATING = (int, long, float, decimal.Decimal, fractions.Fraction,
 
 BoolTypeSpec = _BoolTypeSpec()
 
-ByteTypeSpec = PrimitiveTypeSpec(
-    'byte', ttype.BYTE, ByteValue, _INTEGRAL, int,
-    validate_extra=validate_signed_int(8)
-)
+cdef class _ByteTypeSpec(PrimitiveTypeSpec):
 
-DoubleTypeSpec = PrimitiveTypeSpec(
-    'double', ttype.DOUBLE, DoubleValue, _FLOATING, float
-)
+    def __init__(self):
+        self.name = str('byte')
+        self.code = ttype.BYTE
+        self.value_cls = ByteValue
+        self.surface = _INTEGRAL
+        self.cast = int
+        self.validate_extra = validate_signed_int(8)
 
-I16TypeSpec = PrimitiveTypeSpec(
-    'i16', ttype.I16, I16Value, _INTEGRAL, int,
-    validate_extra=validate_signed_int(16)
-)
+    cpdef void write_to(_ByteTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_byte(value)
 
-I32TypeSpec = PrimitiveTypeSpec(
-    'i32', ttype.I32, I32Value, _INTEGRAL, int,
-    validate_extra=validate_signed_int(32)
-)
+ByteTypeSpec = _ByteTypeSpec()
 
-I64TypeSpec = PrimitiveTypeSpec(
-    'i64', ttype.I64, I64Value, _INTEGRAL, long,
-    validate_extra=validate_signed_int(64)
-)
+cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
+
+    def __init__(self):
+        self.name = str('double')
+        self.code = ttype.DOUBLE
+        self.value_cls = DoubleValue
+        self.surface = _FLOATING
+        self.cast = float
+
+    cpdef void write_to(_DoubleTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_double(value)
+
+DoubleTypeSpec = _DoubleTypeSpec()
+
+cdef class _I16TypeSpec(PrimitiveTypeSpec):
+
+    def __init__(self):
+        self.name = str('i16')
+        self.code = ttype.I16
+        self.value_cls = I16Value
+        self.surface = _INTEGRAL
+        self.cast = int
+        self.validate_extra = validate_signed_int(16)
+
+    cpdef void write_to(_I16TypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_i16(value)
+
+I16TypeSpec = _I16TypeSpec()
+
+cdef class _I32TypeSpec(PrimitiveTypeSpec):
+
+    def __init__(self):
+        self.name = str('i32')
+        self.code = ttype.I32
+        self.value_cls = I32Value
+        self.surface = _INTEGRAL
+        self.cast = int
+        self.validate_extra = validate_signed_int(32)
+
+    cpdef void write_to(_I32TypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_i32(value)
+
+I32TypeSpec = _I32TypeSpec()
+
+cdef class _I64TypeSpec(PrimitiveTypeSpec):
+
+    def __init__(self):
+        self.name = str("i64")
+        self.code = ttype.I64
+        self.value_cls = I64Value
+        self.surface = _INTEGRAL
+        self.cast = long
+        self.validate_extra = validate_signed_int(64)
+
+    cpdef void write_to(_I64TypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        writer.write_i64(value)
+
+I64TypeSpec = _I64TypeSpec()
 
 BinaryTypeSpec = _BinaryTypeSpec()
 

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -25,7 +25,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport SetValue
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport SetHeader, ProtocolWriter
+from thriftrw.protocol.core cimport SetHeader, ProtocolWriter, ProtocolReader
 from . cimport check
 
 __all__ = ['SetTypeSpec']
@@ -52,6 +52,16 @@ cdef class SetTypeSpec(TypeSpec):
     @property
     def name(self):
         return 'set<%s>' % self.vspec.name
+
+    cpdef object read_from(SetTypeSpec self, ProtocolReader reader):
+        cdef SetHeader header = reader.read_set_begin()
+        cdef set output = set()
+        for _ in range(header.size):
+            output.add(self.vspec.read_from(reader))
+
+        reader.read_set_end()
+
+        return output
 
     cpdef Value to_wire(self, object value):
         items = []

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -25,6 +25,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport SetValue
 from thriftrw.wire.value cimport Value
+from thriftrw.protocol.core cimport SetHeader, ProtocolWriter
 from . cimport check
 
 __all__ = ['SetTypeSpec']
@@ -66,6 +67,14 @@ cdef class SetTypeSpec(TypeSpec):
         for x in value:
             items.append(self.vspec.to_primitive(x))
         return items
+
+    cpdef void write_to(SetTypeSpec self, ProtocolWriter writer,
+                        object value) except *:
+        cdef SetHeader header = SetHeader(self.vspec.ttype_code, len(value))
+        writer.write_set_begin(header)
+        for v in value:
+            self.vspec.write_to(writer, v)
+        writer.write_set_end()
 
     cpdef object from_wire(self, Value wire_value):
         check.type_code_matches(self, wire_value)

--- a/thriftrw/spec/struct.pxd
+++ b/thriftrw/spec/struct.pxd
@@ -31,3 +31,4 @@ cdef class StructTypeSpec(TypeSpec):
     cdef public bint linked
     cdef public object surface
 
+    cdef dict _index

--- a/thriftrw/spec/union.pxd
+++ b/thriftrw/spec/union.pxd
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from .base cimport TypeSpec
+from thriftrw.protocol.core cimport ProtocolReader
 
 
 cdef class UnionTypeSpec(TypeSpec):
@@ -30,3 +31,5 @@ cdef class UnionTypeSpec(TypeSpec):
 
     cdef public bint linked
     cdef public object surface
+
+    cdef dict _index

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3,cover,flake8,docs
+envlist = py27,py33,py34,py35,pypy,cover,flake8,docs
 usedevelop = true
 
 [testenv]


### PR DESCRIPTION
This tries to drop the intermediate Value representation of Thrift blobs in favor of the streaming `write_*`/`read_from` approach. The Value representation still exists (we want to support dynamic incoming structs), but during encoding we won't create intermediate structs.

The intention is to do something similar while reading with `read_*` methods. This is very similar to what Apache Thrift already does.

Existing benchmarks show improvement during encoding with these changes.

Before:
```
--------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------
Name (time in us)                                      Min           Max          Mean      StdDev        Median          IQR  Outliers(*)  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------
test_binary_loads[nested_structs]              16,474.0086   33,906.9366   20,297.8651  5,972.9826   17,036.4380   2,691.3881        11;11      48           1
test_binary_loads[primitive_containers]       352,126.8368  374,081.8501  363,660.1448  8,221.5467  362,915.9927  10,945.7970          2;0       5           1
```

After:

```
--------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------
Name (time in us)                                      Min           Max          Mean      StdDev        Median          IQR  Outliers(*)  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------
test_binary_loads[nested_structs]              10,932.9224   29,603.0045   12,143.8092  2,779.9176   11,502.9812    415.9808          3;9      87           1
test_binary_loads[primitive_containers]       103,006.1245  111,021.9955  106,945.2498  2,231.4418  106,887.1021  2,384.5434          2;0       9           1
```