### PR TITLE
fix mutable default args handling

### DIFF
--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+import copy
 from thriftrw.wire cimport ttype
 from thriftrw.wire.value cimport Value
 from thriftrw._cython cimport richcompare
@@ -330,7 +331,7 @@ def struct_init(cls_name, field_names, field_defaults, base_cls, validate):
             default_values = zip(field_names[-num_defaults:], field_defaults)
             for name, value in default_values:
                 if name in unassigned:
-                    setattr(self, name, value)
+                    setattr(self, name, copy.deepcopy(value))
                     unassigned.remove(name)
 
         if kwargs:


### PR DESCRIPTION
thriftrw treats default args in a surprising way—the same way in which Python treats mutable default args—but thrift specs are definitely NOT Python.  This caused a pretty weird bug as I tried to switch over.

I couldn't build this repo on my macbook so I haven't added any test cases yet.