### PR TITLE
requirements: Add version bounds for cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ matrix:
 
 install:
     - pip install tox
-    - pip install cython
+    - pip install 'cython>=0.23,<0.24'
 script:
     - tox -e $TOX_ENV

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cython
+cython>=0.23,<0.24
 six
 ply

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 deps =
     -rrequirements-test.txt
     coveralls
-    cython
+    cython>=0.23,<0.24
 commands =
     python setup.py clean --all build_ext --force --inplace
     py.test --cov thriftrw --cov-config .coveragerc --cov-report=xml --cov-report=term-missing tests


### PR DESCRIPTION
We're currently broken with cython 0.24 because of some changes to how enums work in the new version.

@breerly 