### PR TITLE
structs: Don't persist mutations to default values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Releases
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed a bug that caused mutations to default values of structs to be
+  persisted across calls.
 
 
 1.2.4 (2016-03-04)

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+import copy
+
 from thriftrw.wire cimport ttype
 from thriftrw.wire.value cimport Value
 from thriftrw._cython cimport richcompare
@@ -330,7 +332,7 @@ def struct_init(cls_name, field_names, field_defaults, base_cls, validate):
             default_values = zip(field_names[-num_defaults:], field_defaults)
             for name, value in default_values:
                 if name in unassigned:
-                    setattr(self, name, value)
+                    setattr(self, name, copy.deepcopy(value))
                     unassigned.remove(name)
 
         if kwargs:


### PR DESCRIPTION
This fixes the issue reported in #127 where we were persisting mutations to
default values of structs.