### PR TITLE
Check the magnitude of integer types in validate().

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Releases
 1.2.6 (unreleased)
 ------------------
 
-- Changed PrimitiveTypeSpec.validate() to check that the values of
+- Changed ``PrimitiveTypeSpec.validate()`` to check that the values of
   integer fields fit in the required number of bits.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Releases
 1.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed PrimitiveTypeSpec.validate() to check that the values of
+  integer fields fit in the required number of bits.
 
 
 1.2.5 (2016-09-07)

--- a/tests/spec/test_list.py
+++ b/tests/spec/test_list.py
@@ -70,13 +70,13 @@ def test_primitive(parse, scope, loads):
     value = [
         Foo(1234),
         Foo(1234567890),
-        Foo(12345678901234567890),
+        Foo(1234567890123456789),
     ]
 
     prim_value = [
         {'i': 1234},
         {'i': 1234567890},
-        {'i': 12345678901234567890},
+        {'i': 1234567890123456789},
     ]
 
     assert spec.to_primitive(value) == prim_value

--- a/tests/spec/test_primitive.py
+++ b/tests/spec/test_primitive.py
@@ -23,6 +23,10 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
 
+from thriftrw.spec.primitive import ByteTypeSpec
+from thriftrw.spec.primitive import I16TypeSpec
+from thriftrw.spec.primitive import I32TypeSpec
+from thriftrw.spec.primitive import I64TypeSpec
 from thriftrw.spec.primitive import TextTypeSpec
 from thriftrw.wire.value import BinaryValue
 
@@ -63,3 +67,39 @@ def test_validate():
 
     with pytest.raises(TypeError):
         spec.validate(1)
+
+
+def test_validate_byte():
+    ByteTypeSpec.validate(127)
+    ByteTypeSpec.validate(-128)
+    with pytest.raises(OverflowError):
+        ByteTypeSpec.validate(128)
+    with pytest.raises(OverflowError):
+        ByteTypeSpec.validate(-129)
+
+
+def test_validate_i16():
+    I16TypeSpec.validate(32767)
+    I16TypeSpec.validate(-32768)
+    with pytest.raises(OverflowError):
+        I16TypeSpec.validate(32768)
+    with pytest.raises(OverflowError):
+        I16TypeSpec.validate(-32769)
+
+
+def test_validate_i32():
+    I32TypeSpec.validate(2147483647)
+    I32TypeSpec.validate(-2147483648)
+    with pytest.raises(OverflowError):
+        I32TypeSpec.validate(2147483648)
+    with pytest.raises(OverflowError):
+        I32TypeSpec.validate(-2147483649)
+
+
+def test_validate_i64():
+    I64TypeSpec.validate(9223372036854775807)
+    I64TypeSpec.validate(-9223372036854775808)
+    with pytest.raises(OverflowError):
+        I64TypeSpec.validate(9223372036854775808)
+    with pytest.raises(OverflowError):
+        I64TypeSpec.validate(-9223372036854775809)

--- a/tests/spec/test_primitive.py
+++ b/tests/spec/test_primitive.py
@@ -72,34 +72,34 @@ def test_validate():
 def test_validate_byte():
     ByteTypeSpec.validate(127)
     ByteTypeSpec.validate(-128)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         ByteTypeSpec.validate(128)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         ByteTypeSpec.validate(-129)
 
 
 def test_validate_i16():
     I16TypeSpec.validate(32767)
     I16TypeSpec.validate(-32768)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I16TypeSpec.validate(32768)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I16TypeSpec.validate(-32769)
 
 
 def test_validate_i32():
     I32TypeSpec.validate(2147483647)
     I32TypeSpec.validate(-2147483648)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I32TypeSpec.validate(2147483648)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I32TypeSpec.validate(-2147483649)
 
 
 def test_validate_i64():
     I64TypeSpec.validate(9223372036854775807)
     I64TypeSpec.validate(-9223372036854775808)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I64TypeSpec.validate(9223372036854775808)
-    with pytest.raises(OverflowError):
+    with pytest.raises(ValueError):
         I64TypeSpec.validate(-9223372036854775809)

--- a/thriftrw/spec/primitive.pxd
+++ b/thriftrw/spec/primitive.pxd
@@ -31,6 +31,7 @@ cdef class PrimitiveTypeSpec(TypeSpec):
     cdef readonly object value_cls
     cdef readonly object surface
     cdef readonly object cast
+    cdef readonly object validate_extra
 
 
 cdef class _TextualTypeSpec(TypeSpec):

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -238,7 +238,7 @@ def validate_signed_int(bits):
     max = max_magnitude - 1
     def _validate_signed_int(x):
         if x < min or x > max:
-            raise OverflowError('Value %d does not fit in an i%d' % (x, bits))
+            raise ValueError('Value %d does not fit in an i%d' % (x, bits))
     return _validate_signed_int
 
 

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -234,10 +234,10 @@ cdef class _BoolTypeSpec(TypeSpec):
 
 def validate_signed_int(bits):
     max_magnitude = 1 << (bits - 1)
-    min = -1 * max_magnitude
-    max = max_magnitude - 1
+    min_value = -1 * max_magnitude
+    max_value = max_magnitude - 1
     def _validate_signed_int(x):
-        if x < min or x > max:
+        if x < min_value or x > max_value:
             raise ValueError('Value %d does not fit in an i%d' % (x, bits))
     return _validate_signed_int
 


### PR DESCRIPTION
This partially fixes GitHub issue #131.

This is not a complete solution, as the error message is still opaque, but it's an improvement.  Throwing the error at struct creation time instead of at serialization time makes it clearer which struct has a bad field, and makes it easier for TChannel clients to handle, since TChannel doesn't seem to provide a way to catch response serialization exceptions.