### PR TITLE
In StructTypeSpec.validate exceptions, indicate which field failed to validate.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Releases
 
 - Changed ``PrimitiveTypeSpec.validate()`` to check that the values of
   integer fields fit in the required number of bits.
+- Include the field ID and struct name in the exception messages from
+  ``StructTypeSpec.validate()``.
 
 
 1.2.5 (2016-09-07)

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -220,6 +220,19 @@ def test_required_field_missing(loads):
     assert 'Field "foo" of "X" is required' in str(exc_info)
 
 
+def test_int_field_too_large(loads):
+    X = loads('struct X { 1: optional i16 foo }').X
+    spec = X.type_spec
+
+    x = X()
+    x.foo = 1000000000000
+
+    with pytest.raises(ValueError) as exc_info:
+        spec.validate(x)
+
+    assert 'Field 1 of X is invalid' in str(exc_info)
+
+
 def test_empty(loads):
     S = loads('struct S {}').S
     spec = S.type_spec

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -216,7 +216,12 @@ cdef class StructTypeSpec(TypeSpec):
                     )
                 else:
                     continue
-            field.spec.validate(field_value)
+            try:
+                field.spec.validate(field_value)
+            except (ValueError, TypeError) as e:
+                raise e.__class__(
+                    'Field %d of %s is invalid: %s' % (field.id, self.name, e)
+                )
 
     def __str__(self):
         return '%s(name=%r, fields=%r)' % (


### PR DESCRIPTION
Together with pull request #132, this fixes GitHub issue #131. The two combined should provide enough information, close enough to the site of the error, for clients to easily debug integer-out-of-bounds issues.