### PR TITLE
Refactor read path to stream directly from memory buffer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 *.so
 .benchmarks/
 .coverage
+.idea/

--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -25,6 +25,7 @@ import pytest
 from thriftrw.errors import ThriftProtocolError
 from thriftrw.errors import EndOfInputError
 from thriftrw.protocol.binary import BinaryProtocol
+from thriftrw._buffer import ReadBuffer, WriteBuffer
 from thriftrw.wire import ttype
 from thriftrw.wire import value
 from thriftrw.wire import Message
@@ -35,6 +36,11 @@ from ..util.value import (
     vstruct,
 )
 
+from ..util.spec import (
+    sbin, sbool, sbyte, sdouble, si16, si32, si64, smap, stext, slist,
+    sstruct, sunion, sf, sset
+)
+
 
 def reader_writer_ids(x):
     if isinstance(x, (list, value.Value)):
@@ -42,119 +48,138 @@ def reader_writer_ids(x):
     return ttype.name_of(x)
 
 
-@pytest.mark.parametrize('typ, bs, value', [
+@pytest.mark.parametrize('typ, bs, spec, value', [
     # bool
-    (ttype.BOOL, [0x01], vbool(True)),
-    (ttype.BOOL, [0x00], vbool(False)),
+    (ttype.BOOL, [0x01], sbool, vbool(True)),
+    (ttype.BOOL, [0x00], sbool, vbool(False)),
 
     # byte
-    (ttype.BYTE, [0x00], vbyte(0)),
-    (ttype.BYTE, [0x01], vbyte(1)),
-    (ttype.BYTE, [0xff], vbyte(-1)),
-    (ttype.BYTE, [0x7f], vbyte(127)),
-    (ttype.BYTE, [0x80], vbyte(-128)),
+    (ttype.BYTE, [0x00], sbyte, vbyte(0)),
+    (ttype.BYTE, [0x01], sbyte, vbyte(1)),
+    (ttype.BYTE, [0xff], sbyte, vbyte(-1)),
+    (ttype.BYTE, [0x7f], sbyte, vbyte(127)),
+    (ttype.BYTE, [0x80], sbyte, vbyte(-128)),
 
     # i16
-    (ttype.I16, [0x00, 0x01], vi16(1)),
-    (ttype.I16, [0x00, 0xff], vi16(255)),
-    (ttype.I16, [0x01, 0x00], vi16(256)),
-    (ttype.I16, [0x01, 0x01], vi16(257)),
-    (ttype.I16, [0x7f, 0xff], vi16(32767)),
-    (ttype.I16, [0xff, 0xff], vi16(-1)),
-    (ttype.I16, [0xff, 0xfe], vi16(-2)),
-    (ttype.I16, [0xff, 0x00], vi16(-256)),
-    (ttype.I16, [0xff, 0x01], vi16(-255)),
-    (ttype.I16, [0x80, 0x00], vi16(-32768)),
+    (ttype.I16, [0x00, 0x01], si16, vi16(1)),
+    (ttype.I16, [0x00, 0xff], si16, vi16(255)),
+    (ttype.I16, [0x01, 0x00], si16, vi16(256)),
+    (ttype.I16, [0x01, 0x01], si16, vi16(257)),
+    (ttype.I16, [0x7f, 0xff], si16, vi16(32767)),
+    (ttype.I16, [0xff, 0xff], si16, vi16(-1)),
+    (ttype.I16, [0xff, 0xfe], si16, vi16(-2)),
+    (ttype.I16, [0xff, 0x00], si16, vi16(-256)),
+    (ttype.I16, [0xff, 0x01], si16, vi16(-255)),
+    (ttype.I16, [0x80, 0x00], si16, vi16(-32768)),
 
     # i32
-    (ttype.I32, [0x00, 0x00, 0x00, 0x01], vi32(1)),
-    (ttype.I32, [0x00, 0x00, 0x00, 0xff], vi32(255)),
-    (ttype.I32, [0x00, 0x00, 0xff, 0xff], vi32(65535)),
-    (ttype.I32, [0x00, 0xff, 0xff, 0xff], vi32(16777215)),
-    (ttype.I32, [0x7f, 0xff, 0xff, 0xff], vi32(2147483647)),
-    (ttype.I32, [0xff, 0xff, 0xff, 0xff], vi32(-1)),
-    (ttype.I32, [0xff, 0xff, 0xff, 0x00], vi32(-256)),
-    (ttype.I32, [0xff, 0xff, 0x00, 0x00], vi32(-65536)),
-    (ttype.I32, [0xff, 0x00, 0x00, 0x00], vi32(-16777216)),
-    (ttype.I32, [0x80, 0x00, 0x00, 0x00], vi32(-2147483648)),
+    (ttype.I32, [0x00, 0x00, 0x00, 0x01], si32, vi32(1)),
+    (ttype.I32, [0x00, 0x00, 0x00, 0xff], si32, vi32(255)),
+    (ttype.I32, [0x00, 0x00, 0xff, 0xff], si32, vi32(65535)),
+    (ttype.I32, [0x00, 0xff, 0xff, 0xff], si32, vi32(16777215)),
+    (ttype.I32, [0x7f, 0xff, 0xff, 0xff], si32, vi32(2147483647)),
+    (ttype.I32, [0xff, 0xff, 0xff, 0xff], si32, vi32(-1)),
+    (ttype.I32, [0xff, 0xff, 0xff, 0x00], si32, vi32(-256)),
+    (ttype.I32, [0xff, 0xff, 0x00, 0x00], si32, vi32(-65536)),
+    (ttype.I32, [0xff, 0x00, 0x00, 0x00], si32, vi32(-16777216)),
+    (ttype.I32, [0x80, 0x00, 0x00, 0x00], si32, vi32(-2147483648)),
 
     # i64
     (ttype.I64,
      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01],
+     si64,
      vi64(1)),
     (ttype.I64,
      [0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(4294967295)),
     (ttype.I64,
      [0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(1099511627775)),
     (ttype.I64,
      [0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(281474976710655)),
     (ttype.I64,
      [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(72057594037927935)),
     (ttype.I64,
      [0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(9223372036854775807)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+     si64,
      vi64(-1)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-4294967296)),
     (ttype.I64,
      [0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-1099511627776)),
     (ttype.I64,
      [0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-281474976710656)),
     (ttype.I64,
      [0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-72057594037927936)),
     (ttype.I64,
      [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     si64,
      vi64(-9223372036854775808)),
 
     # double
     (ttype.DOUBLE,
      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     sdouble,
      vdouble(0.0)),
     (ttype.DOUBLE,
      [0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+     sdouble,
      vdouble(1.0)),
     (ttype.DOUBLE,
      [0x3f, 0xf0, 0x0, 0x0, 0x0, 0x6, 0xdf, 0x38],
+     sdouble,
      vdouble(1.0000000001)),
     (ttype.DOUBLE,
      [0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a],
+     sdouble,
      vdouble(1.1)),
     (ttype.DOUBLE,
      [0xbf, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a],
+     sdouble,
      vdouble(-1.1)),
     (ttype.DOUBLE,
      [0x40, 0x9, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18],
+     sdouble,
      vdouble(3.141592653589793)),
     (ttype.DOUBLE,
      [0xbf, 0xf0, 0x0, 0x0, 0x0, 0x6, 0xdf, 0x38],
+     sdouble,
      vdouble(-1.0000000001)),
 
     # binary = len:4 (.){len}
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x00], vbinary(b'')),
+    (ttype.BINARY, [0x00, 0x00, 0x00, 0x00], sbin, vbinary(b'')),
     (ttype.BINARY, [
         0x00, 0x00, 0x00, 0x05,         # len:4 = 5
         0x68, 0x65, 0x6c, 0x6c, 0x6f,   # 'h', 'e', 'l', 'l', 'o'
-    ], vbinary(b'hello')),
+    ], sbin, vbinary(b'hello')),
 
     # struct = (type:1 id:2 value)* stop
     # stop = 0
-    (ttype.STRUCT, [0x00], vstruct()),
+    (ttype.STRUCT, [0x00], sstruct(''), vstruct()),
     (ttype.STRUCT, [
         0x02,        # type:1 = bool
         0x00, 0x01,  # id:2 = 1
         0x01,        # value = true
         0x00,        # stop
-    ], vstruct((1, ttype.BOOL, vbool(True)))),
+    ], sstruct("1: optional bool param"), vstruct((1, ttype.BOOL, vbool(True)))),
     (ttype.STRUCT, [
         0x06,           # type:1 = i16
         0x00, 0x01,     # id:2 = 1
@@ -177,14 +202,14 @@ def reader_writer_ids(x):
         # </list>
 
         0x00,           # stop
-    ], vstruct(
+    ], sstruct("1: optional i16 p1; 2: optional list<binary> p2;"), vstruct(
         (1, ttype.I16, vi16(42)),
         (2, ttype.LIST, vlist(
             ttype.BINARY, vbinary(b'foo'), vbinary(b'bar'))),
     )),
 
     # map = ktype:1 vtype:1 count:4 (key value){count}
-    (ttype.MAP, [0x0A, 0X0B, 0x00, 0x00, 0x00, 0x00],
+    (ttype.MAP, [0x0A, 0X0B, 0x00, 0x00, 0x00, 0x00], smap(si64, sbin),
      vmap(ttype.I64, ttype.BINARY)),
     (ttype.MAP, [
         0x0B,   # ktype = binary
@@ -209,26 +234,26 @@ def reader_writer_ids(x):
         0x62,                    # 'b'
         # </key>
         # <value>
-        0x06,                    # type:1 = 6
+        0x03,                    # type:1 = 6
         0x00, 0x00, 0x00, 0x02,  # count:4 = 2
-        0x00, 0x02,              # 2
-        0x00, 0x03,              # 3
+        0x02,              # 2
+        0x03,              # 3
         # </value>
         # </item>
-    ], vmap(
+    ], smap(sbin, slist(sbyte)), vmap(
         ttype.BINARY, ttype.LIST,
         (vbinary(b'a'), vlist(ttype.BYTE, vbyte(1))),
-        (vbinary(b'b'), vlist(ttype.I16, vi16(2), vi16(3))),
+        (vbinary(b'b'), vlist(ttype.BYTE, vbyte(2), vbyte(3))),
     )),
 
     # set = vtype:1 count:4 (value){count)
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00, 0x00], vset(ttype.BOOL)),
+    (ttype.SET, [0x02, 0x00, 0x00, 0x00, 0x00], sset(sbool), vset(ttype.BOOL)),
     (ttype.SET, [
-        0x02, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x01
-    ], vset(ttype.BOOL, vbool(True), vbool(False), vbool(True))),
+        0x02, 0x00, 0x00, 0x00, 0x01, 0x01
+    ], sset(sbool), vset(ttype.BOOL, vbool(True))),
 
     # list = vtype:1 count:4 (value){count}
-    (ttype.LIST, [0x0C, 0x00, 0x00, 0x00, 0x00], vlist(ttype.STRUCT)),
+    (ttype.LIST, [0x0C, 0x00, 0x00, 0x00, 0x00], slist(sstruct('')), vlist(ttype.STRUCT)),
     (ttype.LIST, [
         0x0C,                       # vtype:1 = struct
         0x00, 0x00, 0x00, 0x02,     # count:4 = 2
@@ -256,13 +281,13 @@ def reader_writer_ids(x):
 
         0x00,        # stop
         # </struct>
-    ], vlist(
+    ], slist(sstruct("1: optional i16 p1; 2: optional i32 p2")), vlist(
         ttype.STRUCT,
         vstruct((1, ttype.I16, vi16(1)), (2, ttype.I32, vi32(2))),
         vstruct((1, ttype.I16, vi16(3)), (2, ttype.I32, vi32(4))),
     )),
 ], ids=reader_writer_ids)
-def test_reader_and_writer(typ, bs, value):
+def test_reader_and_writer(typ, bs, spec, value):
     """Test serialization and deserialization of all samples."""
     bs = bytes(bytearray(bs))
 
@@ -274,61 +299,72 @@ def test_reader_and_writer(typ, bs, value):
     result = protocol.serialize_value(value)
     assert bs == result
 
+    buffer = ReadBuffer(bs)
+    deserialized = spec.read_from(protocol.reader(buffer))
+    buffer = WriteBuffer()
+    spec.write_to(protocol.writer(buffer), deserialized)
 
-@pytest.mark.parametrize('typ, bs', [
-    (ttype.BOOL, []),
-    (ttype.BYTE, []),
-    (ttype.DOUBLE, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
-    (ttype.I16, [0x01]),
-    (ttype.I32, [0x01, 0x02, 0x03]),
-    (ttype.I64, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    assert bs == buffer.value
 
-    (ttype.BINARY, []),
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x01]),
-    (ttype.BINARY, [0x00, 0x00, 0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c]),
 
-    (ttype.STRUCT, []),
-    (ttype.STRUCT, [0x02, 0x01]),
-    (ttype.STRUCT, [0x06, 0x00, 0x01, 0x00, 0x01]),
+@pytest.mark.parametrize('typ, spec, bs', [
+    (ttype.BOOL, sbool, []),
+    (ttype.BYTE, sbyte, []),
+    (ttype.DOUBLE, sdouble, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    (ttype.I16, si16, [0x01]),
+    (ttype.I32, si32, [0x01, 0x02, 0x03]),
+    (ttype.I64, si64, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
 
-    (ttype.MAP, []),
-    (ttype.MAP, [0x02, 0x03]),
-    (ttype.MAP, [0x02, 0x03, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.MAP, [
+    (ttype.BINARY, sbin, []),
+    (ttype.BINARY, sbin, [0x00, 0x00, 0x00, 0x01]),
+    (ttype.BINARY, sbin, [0x00, 0x00, 0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c]),
+
+    (ttype.STRUCT, sstruct("1: optional bool p1"), []),
+    (ttype.STRUCT, sstruct("1: optional bool p1"), [0x02, 0x01]),
+    (ttype.STRUCT, sstruct("1: optional i16 p1"), [0x06, 0x00, 0x01, 0x00, 0x01]),
+
+    (ttype.MAP, smap(si32, sbyte), []),
+    (ttype.MAP, smap(si32, sbyte), [0x02, 0x03]),
+    (ttype.MAP, smap(si32, sbyte), [0x02, 0x03, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.MAP, smap(si32, sbyte), [
         0x02, 0x03,                 # ktype vtype
         0x00, 0x00, 0x00, 0x02,     # len = 2
         0x00, 0x01,                 # (False, 1)
         0x01                        # (True, ?)
     ]),
 
-    (ttype.SET, []),
-    (ttype.SET, [0x02]),
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00]),
-    (ttype.SET, [0x02, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.SET, [
+    (ttype.SET, sset(sbool), []),
+    (ttype.SET, sset(sbool), [0x02]),
+    (ttype.SET, sset(sbool), [0x02, 0x00, 0x00, 0x00]),
+    (ttype.SET, sset(sbool), [0x02, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.SET, sset(sbool), [
         0x02,                    # typ
         0x00, 0x00, 0x00, 0x02,  # len = 2
         0x01,                    # True
     ]),
 
-    (ttype.LIST, []),
-    (ttype.LIST, [0x02]),
-    (ttype.LIST, [0x02, 0x00, 0x00, 0x00]),
-    (ttype.LIST, [0x02, 0x00, 0x00, 0x00, 0x01]),
-    (ttype.LIST, [
+    (ttype.LIST, slist(sbool), []),
+    (ttype.LIST, slist(sbool), [0x02]),
+    (ttype.LIST, slist(sbool), [0x02, 0x00, 0x00, 0x00]),
+    (ttype.LIST, slist(sbool), [0x02, 0x00, 0x00, 0x00, 0x01]),
+    (ttype.LIST, slist(sbool), [
         0x02,                    # typ
         0x00, 0x00, 0x00, 0x02,  # len = 2
         0x01,                    # True
     ]),
 ], ids=reader_writer_ids)
-def test_input_too_short(typ, bs):
+def test_input_too_short(typ, spec, bs):
     """Test that EndOfInputError is raised when not enough bytes are
     available."""
 
     protocol = BinaryProtocol()
 
     with pytest.raises(EndOfInputError) as exc_info:
-        protocol.deserialize_value(typ, bytes(bytearray(bs)))
+        s = bytes(bytearray(bs))
+        protocol.deserialize_value(typ, s)
+
+        reader = protocol.reader(ReadBuffer(s))
+        spec.read_from(reader)
 
     assert 'bytes but got' in str(exc_info)
 

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -165,118 +165,118 @@ def test_link_unknown_parent(loads):
     assert 'Unknown service "B" referenced at line' in str(exc_info)
 
 
-# def test_load(loads):
-#     keyvalue = loads('''
-#         service KeyValue extends BaseService {
-#             void putItem(
-#                 1: string key,
-#                 2: Item item,
-#             ) throws (1: ItemAlreadyExists alreadyExists);
-#
-#             Item getItem(
-#                 1: string key,
-#             ) throws (1: KeyDoesNotExist doesNotExist);
-#
-#             oneway void clear();
-#         }
-#
-#         struct Item {
-#             1: required map<string, Value> attributes
-#         }
-#
-#         union Value {
-#             1: string stringValue
-#             2: i32 intValue
-#             3: list<Value> listValue
-#         }
-#
-#         exception ItemAlreadyExists { 1: required string message }
-#         exception KeyDoesNotExist   { 1: required string message }
-#
-#         service BaseService {
-#             bool healthy()
-#
-#             /* doesn't accept or return anything */
-#             void noop();
-#         }
-#     ''')
-#     assert (
-#         (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.__services__ or
-#         (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.__services__
-#     )
-#
-#     KeyValue = keyvalue.KeyValue
-#
-#     assert KeyValue.clear.spec.oneway
-#     assert KeyValue.clear.request is not None
-#     assert KeyValue.clear.response is None
-#     assert KeyValue.clear.request.result_type is None
-#
-#     assert not KeyValue.putItem.spec.oneway
-#     assert KeyValue.putItem.response.type_spec.return_spec is None
-#     assert (
-#         KeyValue.getItem.response.type_spec.return_spec is
-#         keyvalue.Item.type_spec
-#     )
-#     assert KeyValue.putItem.request.result_type is KeyValue.putItem.response
-#
-#     assert_round_trip(
-#         KeyValue.putItem.request(
-#             'hello',
-#             keyvalue.Item({'a': keyvalue.Value(stringValue=u'world')}),
-#         ),
-#         vstruct(
-#             (1, ttype.BINARY, vbinary(b'hello')),
-#             (2, ttype.STRUCT, vstruct(
-#                 (1, ttype.MAP, vmap(
-#                     ttype.BINARY, ttype.STRUCT,
-#                     (
-#                         vbinary(b'a'),
-#                         vstruct((1, ttype.BINARY, vbinary(b'world'))),
-#                     )
-#                 )),
-#             )),
-#         ),
-#     )
-#
-#     assert_round_trip(KeyValue.putItem.response(), vstruct())
-#
-#     assert_round_trip(
-#         KeyValue.putItem.response(
-#             alreadyExists=keyvalue.ItemAlreadyExists('hello')
-#         ),
-#         vstruct(
-#             (1, ttype.STRUCT, vstruct(
-#                 (1, ttype.BINARY, vbinary(b'hello'))
-#             )),
-#         )
-#     )
-#
-#     assert_round_trip(
-#         KeyValue.getItem.request('somekey'),
-#         vstruct((1, ttype.BINARY, vbinary(b'somekey')))
-#     )
-#
-#     assert_round_trip(KeyValue.noop.request(), vstruct())
-#     assert_round_trip(KeyValue.noop.response(), vstruct())
-#
-#     assert_round_trip(
-#         KeyValue.healthy.request(),
-#         vstruct(),
-#     )
-#
-#     assert_round_trip(
-#         KeyValue.healthy.response(success=True),
-#         vstruct((0, ttype.BOOL, vbool(True))),
-#     )
-#
-#     assert keyvalue.dumps(
-#         KeyValue.healthy.response(success=False)
-#     ) == b'\x02\x00\x00\x00\x00'
-#
-#     assert keyvalue.loads(
-#         KeyValue.healthy.request, b'\x00'
-#     ) == KeyValue.healthy.request()
+def test_load(loads):
+    keyvalue = loads('''
+        service KeyValue extends BaseService {
+            void putItem(
+                1: string key,
+                2: Item item,
+            ) throws (1: ItemAlreadyExists alreadyExists);
+
+            Item getItem(
+                1: string key,
+            ) throws (1: KeyDoesNotExist doesNotExist);
+
+            oneway void clear();
+        }
+
+        struct Item {
+            1: required map<string, Value> attributes
+        }
+
+        union Value {
+            1: string stringValue
+            2: i32 intValue
+            3: list<Value> listValue
+        }
+
+        exception ItemAlreadyExists { 1: required string message }
+        exception KeyDoesNotExist   { 1: required string message }
+
+        service BaseService {
+            bool healthy()
+
+            /* doesn't accept or return anything */
+            void noop();
+        }
+    ''')
+    assert (
+        (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.__services__ or
+        (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.__services__
+    )
+
+    KeyValue = keyvalue.KeyValue
+
+    assert KeyValue.clear.spec.oneway
+    assert KeyValue.clear.request is not None
+    assert KeyValue.clear.response is None
+    assert KeyValue.clear.request.result_type is None
+
+    assert not KeyValue.putItem.spec.oneway
+    assert KeyValue.putItem.response.type_spec.return_spec is None
+    assert (
+        KeyValue.getItem.response.type_spec.return_spec is
+        keyvalue.Item.type_spec
+    )
+    assert KeyValue.putItem.request.result_type is KeyValue.putItem.response
+
+    assert_round_trip(
+        KeyValue.putItem.request(
+            'hello',
+            keyvalue.Item({'a': keyvalue.Value(stringValue=u'world')}),
+        ),
+        vstruct(
+            (1, ttype.BINARY, vbinary(b'hello')),
+            (2, ttype.STRUCT, vstruct(
+                (1, ttype.MAP, vmap(
+                    ttype.BINARY, ttype.STRUCT,
+                    (
+                        vbinary(b'a'),
+                        vstruct((1, ttype.BINARY, vbinary(b'world'))),
+                    )
+                )),
+            )),
+        ),
+    )
+
+    assert_round_trip(KeyValue.putItem.response(), vstruct())
+
+    assert_round_trip(
+        KeyValue.putItem.response(
+            alreadyExists=keyvalue.ItemAlreadyExists('hello')
+        ),
+        vstruct(
+            (1, ttype.STRUCT, vstruct(
+                (1, ttype.BINARY, vbinary(b'hello'))
+            )),
+        )
+    )
+
+    assert_round_trip(
+        KeyValue.getItem.request('somekey'),
+        vstruct((1, ttype.BINARY, vbinary(b'somekey')))
+    )
+
+    assert_round_trip(KeyValue.noop.request(), vstruct())
+    assert_round_trip(KeyValue.noop.response(), vstruct())
+
+    assert_round_trip(
+        KeyValue.healthy.request(),
+        vstruct(),
+    )
+
+    assert_round_trip(
+        KeyValue.healthy.response(success=True),
+        vstruct((0, ttype.BOOL, vbool(True))),
+    )
+
+    assert keyvalue.dumps(
+        KeyValue.healthy.response(success=False)
+    ) == b'\x02\x00\x00\x00\x00'
+
+    assert keyvalue.loads(
+        KeyValue.healthy.request, b'\x00'
+    ) == KeyValue.healthy.request()
 
 
 def test_fails_on_absent_return_value(loads):

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -165,118 +165,118 @@ def test_link_unknown_parent(loads):
     assert 'Unknown service "B" referenced at line' in str(exc_info)
 
 
-def test_load(loads):
-    keyvalue = loads('''
-        service KeyValue extends BaseService {
-            void putItem(
-                1: string key,
-                2: Item item,
-            ) throws (1: ItemAlreadyExists alreadyExists);
-
-            Item getItem(
-                1: string key,
-            ) throws (1: KeyDoesNotExist doesNotExist);
-
-            oneway void clear();
-        }
-
-        struct Item {
-            1: required map<string, Value> attributes
-        }
-
-        union Value {
-            1: string stringValue
-            2: i32 intValue
-            3: list<Value> listValue
-        }
-
-        exception ItemAlreadyExists { 1: required string message }
-        exception KeyDoesNotExist   { 1: required string message }
-
-        service BaseService {
-            bool healthy()
-
-            /* doesn't accept or return anything */
-            void noop();
-        }
-    ''')
-    assert (
-        (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.__services__ or
-        (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.__services__
-    )
-
-    KeyValue = keyvalue.KeyValue
-
-    assert KeyValue.clear.spec.oneway
-    assert KeyValue.clear.request is not None
-    assert KeyValue.clear.response is None
-    assert KeyValue.clear.request.result_type is None
-
-    assert not KeyValue.putItem.spec.oneway
-    assert KeyValue.putItem.response.type_spec.return_spec is None
-    assert (
-        KeyValue.getItem.response.type_spec.return_spec is
-        keyvalue.Item.type_spec
-    )
-    assert KeyValue.putItem.request.result_type is KeyValue.putItem.response
-
-    assert_round_trip(
-        KeyValue.putItem.request(
-            'hello',
-            keyvalue.Item({'a': keyvalue.Value(stringValue=u'world')}),
-        ),
-        vstruct(
-            (1, ttype.BINARY, vbinary(b'hello')),
-            (2, ttype.STRUCT, vstruct(
-                (1, ttype.MAP, vmap(
-                    ttype.BINARY, ttype.STRUCT,
-                    (
-                        vbinary(b'a'),
-                        vstruct((1, ttype.BINARY, vbinary(b'world'))),
-                    )
-                )),
-            )),
-        ),
-    )
-
-    assert_round_trip(KeyValue.putItem.response(), vstruct())
-
-    assert_round_trip(
-        KeyValue.putItem.response(
-            alreadyExists=keyvalue.ItemAlreadyExists('hello')
-        ),
-        vstruct(
-            (1, ttype.STRUCT, vstruct(
-                (1, ttype.BINARY, vbinary(b'hello'))
-            )),
-        )
-    )
-
-    assert_round_trip(
-        KeyValue.getItem.request('somekey'),
-        vstruct((1, ttype.BINARY, vbinary(b'somekey')))
-    )
-
-    assert_round_trip(KeyValue.noop.request(), vstruct())
-    assert_round_trip(KeyValue.noop.response(), vstruct())
-
-    assert_round_trip(
-        KeyValue.healthy.request(),
-        vstruct(),
-    )
-
-    assert_round_trip(
-        KeyValue.healthy.response(success=True),
-        vstruct((0, ttype.BOOL, vbool(True))),
-    )
-
-    assert keyvalue.dumps(
-        KeyValue.healthy.response(success=False)
-    ) == b'\x02\x00\x00\x00\x00'
-
-    assert keyvalue.loads(
-        KeyValue.healthy.request, b'\x00'
-    ) == KeyValue.healthy.request()
+# def test_load(loads):
+#     keyvalue = loads('''
+#         service KeyValue extends BaseService {
+#             void putItem(
+#                 1: string key,
+#                 2: Item item,
+#             ) throws (1: ItemAlreadyExists alreadyExists);
+#
+#             Item getItem(
+#                 1: string key,
+#             ) throws (1: KeyDoesNotExist doesNotExist);
+#
+#             oneway void clear();
+#         }
+#
+#         struct Item {
+#             1: required map<string, Value> attributes
+#         }
+#
+#         union Value {
+#             1: string stringValue
+#             2: i32 intValue
+#             3: list<Value> listValue
+#         }
+#
+#         exception ItemAlreadyExists { 1: required string message }
+#         exception KeyDoesNotExist   { 1: required string message }
+#
+#         service BaseService {
+#             bool healthy()
+#
+#             /* doesn't accept or return anything */
+#             void noop();
+#         }
+#     ''')
+#     assert (
+#         (keyvalue.KeyValue, keyvalue.BaseService) == keyvalue.__services__ or
+#         (keyvalue.BaseService, keyvalue.KeyValue) == keyvalue.__services__
+#     )
+#
+#     KeyValue = keyvalue.KeyValue
+#
+#     assert KeyValue.clear.spec.oneway
+#     assert KeyValue.clear.request is not None
+#     assert KeyValue.clear.response is None
+#     assert KeyValue.clear.request.result_type is None
+#
+#     assert not KeyValue.putItem.spec.oneway
+#     assert KeyValue.putItem.response.type_spec.return_spec is None
+#     assert (
+#         KeyValue.getItem.response.type_spec.return_spec is
+#         keyvalue.Item.type_spec
+#     )
+#     assert KeyValue.putItem.request.result_type is KeyValue.putItem.response
+#
+#     assert_round_trip(
+#         KeyValue.putItem.request(
+#             'hello',
+#             keyvalue.Item({'a': keyvalue.Value(stringValue=u'world')}),
+#         ),
+#         vstruct(
+#             (1, ttype.BINARY, vbinary(b'hello')),
+#             (2, ttype.STRUCT, vstruct(
+#                 (1, ttype.MAP, vmap(
+#                     ttype.BINARY, ttype.STRUCT,
+#                     (
+#                         vbinary(b'a'),
+#                         vstruct((1, ttype.BINARY, vbinary(b'world'))),
+#                     )
+#                 )),
+#             )),
+#         ),
+#     )
+#
+#     assert_round_trip(KeyValue.putItem.response(), vstruct())
+#
+#     assert_round_trip(
+#         KeyValue.putItem.response(
+#             alreadyExists=keyvalue.ItemAlreadyExists('hello')
+#         ),
+#         vstruct(
+#             (1, ttype.STRUCT, vstruct(
+#                 (1, ttype.BINARY, vbinary(b'hello'))
+#             )),
+#         )
+#     )
+#
+#     assert_round_trip(
+#         KeyValue.getItem.request('somekey'),
+#         vstruct((1, ttype.BINARY, vbinary(b'somekey')))
+#     )
+#
+#     assert_round_trip(KeyValue.noop.request(), vstruct())
+#     assert_round_trip(KeyValue.noop.response(), vstruct())
+#
+#     assert_round_trip(
+#         KeyValue.healthy.request(),
+#         vstruct(),
+#     )
+#
+#     assert_round_trip(
+#         KeyValue.healthy.response(success=True),
+#         vstruct((0, ttype.BOOL, vbool(True))),
+#     )
+#
+#     assert keyvalue.dumps(
+#         KeyValue.healthy.response(success=False)
+#     ) == b'\x02\x00\x00\x00\x00'
+#
+#     assert keyvalue.loads(
+#         KeyValue.healthy.request, b'\x00'
+#     ) == KeyValue.healthy.request()
 
 
 def test_fails_on_absent_return_value(loads):

--- a/tests/util/spec.py
+++ b/tests/util/spec.py
@@ -1,0 +1,54 @@
+import re
+
+from thriftrw.spec.primitive import (
+    BinaryTypeSpec as sbin,
+    BoolTypeSpec as sbool,
+    ByteTypeSpec as sbyte,
+    DoubleTypeSpec as sdouble,
+    I16TypeSpec as si16,
+    I32TypeSpec as si32,
+    I64TypeSpec as si64,
+    TextTypeSpec as stext,
+)
+
+from thriftrw.spec.list import ListTypeSpec
+from thriftrw.spec.map import MapTypeSpec
+from thriftrw.spec.struct import StructTypeSpec
+from thriftrw.spec.union import UnionTypeSpec
+from thriftrw.spec.field import FieldSpec
+from thriftrw.spec.set import SetTypeSpec
+from thriftrw.idl import Parser
+from thriftrw.compile.scope import Scope
+
+
+parse = Parser(start='struct', silent=True).parse
+
+
+def sstruct(fields):
+    struct_ast = parse('struct RefStruct {{ {} }}'.format(fields))
+    spec = StructTypeSpec.compile(struct_ast)
+    spec.link(Scope("test"))
+    return spec
+
+
+def smap(key, value):
+    return MapTypeSpec(key, value)
+
+
+def sunion(*fields):
+    return UnionTypeSpec("test", list(fields))
+
+
+def sf(id, spec, name=None, required=False, default_value=None):
+    if name is None:
+        name = re.sub("[^a-zA-Z_0-9]+", "", str(spec) + str(id))
+
+    return FieldSpec(id, name, spec, required, default_value)
+
+
+def sset(value):
+    return SetTypeSpec(value)
+
+
+def slist(value):
+    return ListTypeSpec(value)

--- a/thriftrw/_buffer.pxd
+++ b/thriftrw/_buffer.pxd
@@ -33,7 +33,7 @@ cdef class ReadBuffer(object):
 
     cpdef bytes take(self, int count)
 
-    cpdef void skip(self, int count)
+    cpdef void skip(self, int count) except *
 
 
 cdef class WriteBuffer(object):

--- a/thriftrw/_buffer.pxd
+++ b/thriftrw/_buffer.pxd
@@ -33,6 +33,8 @@ cdef class ReadBuffer(object):
 
     cpdef bytes take(self, int count)
 
+    cpdef void skip(self, int count)
+
 
 cdef class WriteBuffer(object):
     cdef char* data

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -167,7 +167,7 @@ cdef class ReadBuffer(object):
 
         return result
 
-    cpdef void skip(self, int count):
+    cpdef void skip(self, int count) except *:
         """Seek ``count`` bytes without performing any memory copying.
 
         :param int count:

--- a/thriftrw/_buffer.pyx
+++ b/thriftrw/_buffer.pyx
@@ -167,6 +167,23 @@ cdef class ReadBuffer(object):
 
         return result
 
+    cpdef void skip(self, int count):
+        """Seek ``count`` bytes without performing any memory copying.
+
+        :param int count:
+            Number of bytes to read.
+        :raises EndOfInputError:
+            If the number of bytes available in the buffer is less than
+            ``count``.
+        """
+        if count > self.length - self.offset:
+            raise EndOfInputError(
+                'Expected %d bytes but got %d bytes.' %
+                (count, self.available)
+            )
+
+        self.offset += count
+
     property available:
         """Number of bytes available in the buffer."""
 

--- a/thriftrw/_runtime.pyx
+++ b/thriftrw/_runtime.pyx
@@ -27,10 +27,10 @@ from libc.stdint cimport int32_t
 
 from thriftrw._buffer cimport WriteBuffer, ReadBuffer
 from thriftrw.protocol.core cimport (
-    Protocol,
-    ProtocolWriter,
-    ProtocolReader,
-    MessageHeader,
+Protocol,
+ProtocolWriter,
+ProtocolReader,
+MessageHeader,
 )
 from thriftrw.wire cimport mtype
 from thriftrw.wire cimport ttype
@@ -44,9 +44,7 @@ from thriftrw.errors import (
     UnknownExceptionError,
 )
 
-
 cdef class Serializer(object):
-
     def __cinit__(self, Protocol protocol):
         self.protocol = protocol
 
@@ -112,9 +110,7 @@ cdef class Serializer(object):
 
         return buff.value
 
-
 cdef class Deserializer(object):
-
     def __cinit__(self, Protocol protocol):
         self.protocol = protocol
 
@@ -134,7 +130,7 @@ cdef class Deserializer(object):
         return self.loads(obj_cls, s)
 
     cpdef object loads(self, obj_cls, bytes s):
-        cdef ReadBuffer buff = ReadBuffer()
+        cdef ReadBuffer buff = ReadBuffer(s)
         cdef ProtocolReader reader = self.protocol.reader(buff)
         return obj_cls.type_spec.read_from(reader)
 

--- a/thriftrw/_runtime.pyx
+++ b/thriftrw/_runtime.pyx
@@ -163,7 +163,7 @@ cdef class Deserializer(object):
         if header.type == mtype.EXCEPTION:
             # For EXCEPTION messages, just raise UnknownExceptionError with
             # the struct representation in the message.
-            raise UnknownExceptionError('Received an exception message.', message.body)
+            raise UnknownExceptionError('Received an exception message.', header)
 
         function_spec = service.service_spec.lookup(header.name)
         if function_spec is None:

--- a/thriftrw/_runtime.pyx
+++ b/thriftrw/_runtime.pyx
@@ -25,10 +25,11 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 from libc.stdint cimport int32_t
 
-from thriftrw._buffer cimport WriteBuffer
+from thriftrw._buffer cimport WriteBuffer, ReadBuffer
 from thriftrw.protocol.core cimport (
     Protocol,
     ProtocolWriter,
+    ProtocolReader,
     MessageHeader,
 )
 from thriftrw.wire cimport mtype
@@ -133,8 +134,9 @@ cdef class Deserializer(object):
         return self.loads(obj_cls, s)
 
     cpdef object loads(self, obj_cls, bytes s):
-        cdef Value value = self.protocol.deserialize_value(ttype.STRUCT, s)
-        return obj_cls.type_spec.from_wire(value)
+        cdef ReadBuffer buff = ReadBuffer()
+        cdef ProtocolReader reader = self.protocol.reader(buff)
+        return obj_cls.type_spec.read_from(reader)
 
     cpdef Message message(self, service, bytes s):
         """Deserializes a message from the given blob.

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -63,45 +63,49 @@ cdef class BinaryProtocol(Protocol):
 cdef class BinaryProtocolReader(object):
     cdef ReadBuffer reader
 
+    # Primitives
+
+    cdef bint read_bool(self): pass
+    cdef int8_t read_byte(self): pass
+    cdef double read_double(self): pass
+    cdef int16_t read_i16(self): pass
+    cdef int32_t read_i32(self): pass
+    cdef int64_t read_i64(self): pass
+    cdef bytes read_binary(self): pass
+
+    # Structs: pass
+
+    cdef void read_struct_begin(self): pass
+    cdef FieldHeader read_field_begin(self): pass
+    cdef void read_field_end(self): pass
+    cdef void read_struct_end(self): pass
+
+    # Containers: pass
+
+    cdef MapHeader read_map_begin(self): pass
+    cdef void read_map_end(self): pass
+
+    cdef SetHeader read_set_begin(self): pass
+    cdef void read_set_end(self): pass
+
+    cdef ListHeader read_list_begin(self): pass
+    cdef void read_list_end(self): pass
+
+    # Messages
+
+    cdef MessageHeader read_message_begin(self): pass
+    cdef void read_message_end(self): pass
+
+    # Other
+
     cdef object _reader(self, int8_t typ)
-
     cpdef object read(self, int8_t typ)
-
     cdef void _read(self, char* data, int count) except *
-
     cdef int8_t _byte(self) except *
-
     cdef int16_t _i16(self) except *
-
     cdef int32_t _i32(self) except *
-
     cdef int64_t _i64(self) except *
-
     cdef double _double(self) except *
-
-    cdef Message read_message(self)
-
-    cdef BoolValue read_bool(self)
-
-    cdef ByteValue read_byte(self)
-
-    cdef DoubleValue read_double(self)
-
-    cdef I16Value read_i16(self)
-
-    cdef I32Value read_i32(self)
-
-    cdef I64Value read_i64(self)
-
-    cdef BinaryValue read_binary(self)
-
-    cdef StructValue read_struct(self)
-
-    cdef MapValue read_map(self)
-
-    cdef SetValue read_set(self)
-
-    cdef ListValue read_list(self)
 
 
 cdef class BinaryProtocolWriter(ProtocolWriter):

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -30,6 +30,7 @@ from libc.stdint cimport (
 from .core cimport (
     Protocol,
     ProtocolWriter,
+    ProtocolReader,
     FieldHeader,
     MapHeader,
     SetHeader,
@@ -60,46 +61,9 @@ from thriftrw.wire.value cimport (
 cdef class BinaryProtocol(Protocol):
     pass
 
-cdef class BinaryProtocolReader(object):
+cdef class BinaryProtocolReader(ProtocolReader):
     cdef ReadBuffer reader
 
-    # Primitives
-
-    cdef bint read_bool(self): pass
-    cdef int8_t read_byte(self): pass
-    cdef double read_double(self): pass
-    cdef int16_t read_i16(self): pass
-    cdef int32_t read_i32(self): pass
-    cdef int64_t read_i64(self): pass
-    cdef bytes read_binary(self): pass
-
-    # Structs: pass
-
-    cdef void read_struct_begin(self): pass
-    cdef FieldHeader read_field_begin(self): pass
-    cdef void read_field_end(self): pass
-    cdef void read_struct_end(self): pass
-
-    # Containers: pass
-
-    cdef MapHeader read_map_begin(self): pass
-    cdef void read_map_end(self): pass
-
-    cdef SetHeader read_set_begin(self): pass
-    cdef void read_set_end(self): pass
-
-    cdef ListHeader read_list_begin(self): pass
-    cdef void read_list_end(self): pass
-
-    # Messages
-
-    cdef MessageHeader read_message_begin(self): pass
-    cdef void read_message_end(self): pass
-
-    # Other
-
-    cdef object _reader(self, int8_t typ)
-    cpdef object read(self, int8_t typ)
     cdef void _read(self, char* data, int count) except *
     cdef int8_t _byte(self) except *
     cdef int16_t _i16(self) except *

--- a/thriftrw/protocol/binary.pxd
+++ b/thriftrw/protocol/binary.pxd
@@ -76,3 +76,47 @@ cdef class BinaryProtocolWriter(ProtocolWriter):
     cdef WriteBuffer writer
 
     cdef void _write(BinaryProtocolWriter self, char* data, int length)
+
+
+cdef class _OldBinaryProtocolReader(object):
+    cdef ReadBuffer reader
+
+    cdef object _reader(self, int8_t typ)
+
+    cpdef object read(self, int8_t typ)
+
+    cdef void _read(self, char* data, int count) except *
+
+    cdef int8_t _byte(self) except *
+
+    cdef int16_t _i16(self) except *
+
+    cdef int32_t _i32(self) except *
+
+    cdef int64_t _i64(self) except *
+
+    cdef double _double(self) except *
+
+    cdef Message read_message(self)
+
+    cdef BoolValue read_bool(self)
+
+    cdef ByteValue read_byte(self)
+
+    cdef DoubleValue read_double(self)
+
+    cdef I16Value read_i16(self)
+
+    cdef I32Value read_i32(self)
+
+    cdef I64Value read_i64(self)
+
+    cdef BinaryValue read_binary(self)
+
+    cdef StructValue read_struct(self)
+
+    cdef MapValue read_map(self)
+
+    cdef SetValue read_set(self)
+
+    cdef ListValue read_list(self)

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -125,7 +125,7 @@ cdef class BinaryProtocolReader(ProtocolReader):
 
     cdef void skip_struct(self) except *:
         header = self.read_field_begin()
-        while header.id != 0:
+        while header.type != -1:
             self.skip(header.type)
             header = self.read_field_begin()
 
@@ -214,7 +214,7 @@ cdef class BinaryProtocolReader(ProtocolReader):
     cdef FieldHeader read_field_begin(self):
         cdef int8_t field_type = self._byte()
         if field_type == STRUCT_END:
-            return FieldHeader(0, 0)
+            return FieldHeader(-1, -1)
 
         cdef int16_t field_id = self._i16()
 

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -368,4 +368,250 @@ cdef class BinaryProtocol(Protocol):
     cpdef ProtocolWriter writer(self, WriteBuffer buff):
         return BinaryProtocolWriter(buff)
 
+    cpdef Message deserialize_message(self, bytes s):
+        cdef ReadBuffer buff = ReadBuffer(s)
+        return _OldBinaryProtocolReader(buff).read_message()
+
+    cpdef Value deserialize_value(self, int typ, bytes s):
+        cdef ReadBuffer buff = ReadBuffer(s)
+        return _OldBinaryProtocolReader(buff).read(typ)
+
+
 __all__ = ['BinaryProtocol']
+
+
+cdef class _OldBinaryProtocolReader(object):
+    """Old version of BinaryProtocolReader that returned Value representations.
+
+    Deserialization was refactored in 1.4 to avoid this step as an optimization.
+    This class exists to provide support for backwards compatibility but will
+    be removed in a later version.
+
+    .. deprecated:: 1.4
+    """
+
+    def __cinit__(self, ReadBuffer reader):
+        """Initialize the reader.
+        :param reader:
+            File-like object with a ``read(num)`` method which returns
+            *exactly* the requested number of bytes, or all remaining bytes if
+            ``num`` is negative.
+        """
+        self.reader = reader
+
+    cdef object _reader(self, int8_t typ):
+        if typ == ttype.BOOL:
+            return self.read_bool
+        elif typ == ttype.BYTE:
+            return self.read_byte
+        elif typ == ttype.DOUBLE:
+            return self.read_double
+        elif typ == ttype.I16:
+            return self.read_i16
+        elif typ == ttype.I32:
+            return self.read_i32
+        elif typ == ttype.I64:
+            return self.read_i64
+        elif typ == ttype.BINARY:
+            return self.read_binary
+        elif typ == ttype.STRUCT:
+            return self.read_struct
+        elif typ == ttype.MAP:
+            return self.read_map
+        elif typ == ttype.SET:
+            return self.read_set
+        elif typ == ttype.LIST:
+            return self.read_list
+        else:
+            raise ThriftProtocolError('Unknown TType "%r"' % typ)
+
+    cpdef object read(self, int8_t typ):
+        if typ == ttype.BOOL:
+            return self.read_bool()
+        elif typ == ttype.BYTE:
+            return self.read_byte()
+        elif typ == ttype.DOUBLE:
+            return self.read_double()
+        elif typ == ttype.I16:
+            return self.read_i16()
+        elif typ == ttype.I32:
+            return self.read_i32()
+        elif typ == ttype.I64:
+            return self.read_i64()
+        elif typ == ttype.BINARY:
+            return self.read_binary()
+        elif typ == ttype.STRUCT:
+            return self.read_struct()
+        elif typ == ttype.MAP:
+            return self.read_map()
+        elif typ == ttype.SET:
+            return self.read_set()
+        elif typ == ttype.LIST:
+            return self.read_list()
+        else:
+            raise ThriftProtocolError('Unknown TType "%r"' % typ)
+
+    cdef void _read(self, char* data, int count) except *:
+        self.reader.read(data, count)
+
+    cdef int8_t _byte(self) except *:
+        cdef char c
+        self._read(&c, 1)
+        return <int8_t>c
+
+    cdef int16_t _i16(self) except *:
+        cdef char data[2]
+        self._read(data, 2)
+        return be16toh((<int16_t*>data)[0])
+
+    cdef int32_t _i32(self) except *:
+        cdef char data[4]
+        self._read(data, 4)
+        return be32toh((<int32_t*>data)[0])
+
+    cdef int64_t _i64(self) except *:
+        cdef char data[8]
+        self._read(data, 8)
+        return be64toh((<int64_t*>data)[0])
+
+    cdef double _double(self) except *:
+        cdef int64_t value = self._i64()
+        return (<double*>(&value))[0]
+
+    cdef Message read_message(self):
+        cdef int8_t typ
+        cdef int16_t version
+        cdef int32_t size
+        cdef bytes name
+
+        size = self._i32()
+        # TODO with cython, some of the Python-specific hacks around bit
+        # twiddling can be skipped.
+        if size < 0:
+            # strict version:
+            #
+            #     versionAndType:4 name~4 seqid:4 payload
+            version = (size & VERSION_MASK) >> 16
+            if version != VERSION:
+                raise ThriftProtocolError(
+                    'Unsupported version "%r"' % version
+                )
+            typ = size & TYPE_MASK
+            size = self._i32()
+            name = self.reader.take(size)
+        else:
+            # non-strict version:
+            #
+            #     name:4 type:1 seqid:4 payload
+            name = self.reader.take(size)
+            typ = self._byte()
+
+        seqid = self._i32()
+        body = self.read(ttype.STRUCT)
+
+        return Message(name=name, seqid=seqid, body=body, message_type=typ)
+
+    cdef BoolValue read_bool(self):
+        """Reads a boolean."""
+        return BoolValue(self._byte() == 1)
+
+    cdef ByteValue read_byte(self):
+        """Reads a byte."""
+        return ByteValue(self._byte())
+
+    cdef DoubleValue read_double(self):
+        """Reads a double."""
+        return DoubleValue(self._double())
+
+    cdef I16Value read_i16(self):
+        """Reads a 16-bit integer."""
+        return I16Value(self._i16())
+
+    cdef I32Value read_i32(self):
+        """Reads a 32-bit integer."""
+        return I32Value(self._i32())
+
+    cdef I64Value read_i64(self):
+        """Reads a 64-bit integer."""
+        return I64Value(self._i64())
+
+    cdef BinaryValue read_binary(self):
+        """Reads a binary blob."""
+        cdef int32_t length = self._i32()
+        return BinaryValue(self.reader.take(length))
+
+    cdef StructValue read_struct(self):
+        """Reads an arbitrary Thrift struct."""
+        fields = []
+
+        cdef int8_t field_type = self._byte()
+        cdef int16_t field_id
+
+        while field_type != STRUCT_END:
+            field_id = self._i16()
+            field_value = self.read(field_type)
+            fields.append(
+                FieldValue(
+                    id=field_id,
+                    ttype=field_type,
+                    value=field_value,
+                )
+            )
+
+            field_type = self._byte()
+        return StructValue(fields)
+
+    cdef MapValue read_map(self):
+        """Reads a map."""
+        cdef int8_t key_ttype = self._byte()
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        kreader = self._reader(key_ttype)
+        vreader = self._reader(value_ttype)
+
+        pairs = []
+        for i in range(length):
+            k = kreader(self)
+            v = vreader(self)
+            pairs.append(MapItem(k, v))
+
+        return MapValue(
+            key_ttype=key_ttype,
+            value_ttype=value_ttype,
+            pairs=pairs,
+        )
+
+    cdef SetValue read_set(self):
+        """Reads a set."""
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        vreader = self._reader(value_ttype)
+
+        values = []
+
+        for i in range(length):
+            values.append(vreader(self))
+
+        return SetValue(
+            value_ttype=value_ttype,
+            values=values
+        )
+
+    cdef ListValue read_list(self):
+        """Reads a list."""
+        cdef int8_t value_ttype = self._byte()
+        cdef int32_t length = self._i32()
+
+        vreader = self._reader(value_ttype)
+
+        values = []
+
+        for i in range(length):
+            values.append(vreader(self))
+
+        return ListValue(
+            value_ttype=value_ttype,
+            values=values
+        )

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -100,6 +100,10 @@ cdef class ProtocolWriter(object):
 
 cdef class ProtocolReader:
 
+    # Helpers
+
+    cdef void skip(self, int ttype)
+
     # Primitives
 
     cdef bint read_bool(self)

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -100,42 +100,47 @@ cdef class ProtocolWriter(object):
 
 cdef class ProtocolReader:
 
-    # Helpers
+    # Skip
 
-    cdef void skip(self, int ttype)
+    cdef void skip(self, int typ) except *
+    cdef void skip_binary(self) except *
+    cdef void skip_map(self) except *
+    cdef void skip_list(self) except *
+    cdef void skip_set(self) except *
+    cdef void skip_struct(self) except *
 
     # Primitives
 
-    cdef bint read_bool(self)
-    cdef int8_t read_byte(self)
-    cdef double read_double(self)
-    cdef int16_t read_i16(self)
-    cdef int32_t read_i32(self)
-    cdef int64_t read_i64(self)
+    cdef bint read_bool(self) except *
+    cdef int8_t read_byte(self) except *
+    cdef double read_double(self) except *
+    cdef int16_t read_i16(self) except *
+    cdef int32_t read_i32(self) except *
+    cdef int64_t read_i64(self) except *
     cdef bytes read_binary(self)
 
     # Structs
 
-    cdef void read_struct_begin(self)
+    cdef void read_struct_begin(self) except *
     cdef FieldHeader read_field_begin(self)
-    cdef void read_field_end(self)
-    cdef void read_struct_end(self)
+    cdef void read_field_end(self) except *
+    cdef void read_struct_end(self) except *
 
     # Containers
 
     cdef MapHeader read_map_begin(self)
-    cdef void read_map_end(self)
+    cdef void read_map_end(self) except *
 
     cdef SetHeader read_set_begin(self)
-    cdef void read_set_end(self)
+    cdef void read_set_end(self) except *
 
     cdef ListHeader read_list_begin(self)
-    cdef void read_list_end(self)
+    cdef void read_list_end(self) except *
 
     # Messages
 
     cdef MessageHeader read_message_begin(self)
-    cdef void read_message_end(self)
+    cdef void read_message_end(self) except *
 
 
 cdef class Protocol(object):

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -102,7 +102,7 @@ cdef class ProtocolReader:
 
     # Primitives
 
-    cdef bool read_bool(self)
+    cdef bint read_bool(self)
     cdef int8_t read_byte(self)
     cdef double read_double(self)
     cdef int16_t read_i16(self)

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -30,7 +30,7 @@ from libc.stdint cimport (
 from thriftrw.wire cimport ttype
 from thriftrw.wire.value cimport Value, ValueVisitor
 from thriftrw.wire.message cimport Message
-from thriftrw._buffer cimport WriteBuffer
+from thriftrw._buffer cimport WriteBuffer, ReadBuffer
 
 
 cdef class FieldHeader(object):
@@ -98,8 +98,37 @@ cdef class ProtocolWriter(object):
     cdef void write_message_end(self) except *
 
 
+cdef class ProtocolReader:
+
+    # Primitives
+
+    cdef bool read_bool(self)
+    cdef int8_t read_byte(self)
+    cdef double read_double(self)
+    cdef int16_t read_i16(self)
+    cdef int32_t read_i32(self)
+    cdef int64_t read_i64(self)
+    cdef bytes read_binary(self)
+
+    # Structs
+
+    cdef object read_struct(self)
+
+    # Containers
+
+    cdef dict read_map(self)
+    cdef set read_set(self)
+    cdef list read_list(self)
+
+    # Messages
+
+    cdef Message read_message(self)
+
+
 cdef class Protocol(object):
     cpdef ProtocolWriter writer(self, WriteBuffer buff)
+
+    cpdef ProtocolReader reader(self, ReadBuffer buff)
 
     cpdef bytes serialize_value(self, Value value)
 

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -112,17 +112,26 @@ cdef class ProtocolReader:
 
     # Structs
 
-    cdef object read_struct(self)
+    cdef void read_struct_begin(self)
+    cdef FieldHeader read_field_begin(self)
+    cdef void read_field_end(self)
+    cdef void read_struct_end(self)
 
     # Containers
 
-    cdef dict read_map(self)
-    cdef set read_set(self)
-    cdef list read_list(self)
+    cdef MapHeader read_map_begin(self)
+    cdef void read_map_end(self)
+
+    cdef SetHeader read_set_begin(self)
+    cdef void read_set_end(self)
+
+    cdef ListHeader read_list_begin(self)
+    cdef void read_list_end(self)
 
     # Messages
 
-    cdef Message read_message(self)
+    cdef MessageHeader read_message_begin(self)
+    cdef void read_message_end(self)
 
 
 cdef class Protocol(object):

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -108,6 +108,10 @@ cdef class ProtocolWriter(object):
 
 cdef class ProtocolReader:
 
+    # Helpers
+
+    cdef void skip(self, int typ): pass
+
     # Primitives
 
     cdef bint read_bool(self): pass
@@ -118,14 +122,14 @@ cdef class ProtocolReader:
     cdef int64_t read_i64(self): pass
     cdef bytes read_binary(self): pass
 
-    # Structs: pass
+    # Structs
 
     cdef void read_struct_begin(self): pass
     cdef FieldHeader read_field_begin(self): pass
     cdef void read_field_end(self): pass
     cdef void read_struct_end(self): pass
 
-    # Containers: pass
+    # Containers
 
     cdef MapHeader read_map_begin(self): pass
     cdef void read_map_end(self): pass

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -71,6 +71,14 @@ cdef class MessageHeader(object):
         self.type = type
         self.seqid = seqid
 
+    def __str__(self):
+        return 'MessageHeader(%r, %r, %r)' % (
+            self.name, self.seqid, mtype.name_of(self.type)
+        )
+
+    def __repr__(self):
+        return str(self)
+
 
 cdef class ProtocolWriter(object):
 
@@ -102,7 +110,7 @@ cdef class ProtocolReader:
 
     # Primitives
 
-    cdef bool read_bool(self): pass
+    cdef bint read_bool(self): pass
     cdef int8_t read_byte(self): pass
     cdef double read_double(self): pass
     cdef int16_t read_i16(self): pass

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -98,6 +98,42 @@ cdef class ProtocolWriter(object):
     cdef void write_message_end(self) except *: pass
 
 
+cdef class ProtocolReader:
+
+    # Primitives
+
+    cdef bool read_bool(self): pass
+    cdef int8_t read_byte(self): pass
+    cdef double read_double(self): pass
+    cdef int16_t read_i16(self): pass
+    cdef int32_t read_i32(self): pass
+    cdef int64_t read_i64(self): pass
+    cdef bytes read_binary(self): pass
+
+    # Structs: pass
+
+    cdef void read_struct_begin(self): pass
+    cdef FieldHeader read_field_begin(self): pass
+    cdef void read_field_end(self): pass
+    cdef void read_struct_end(self): pass
+
+    # Containers: pass
+
+    cdef MapHeader read_map_begin(self): pass
+    cdef void read_map_end(self): pass
+
+    cdef SetHeader read_set_begin(self): pass
+    cdef void read_set_end(self): pass
+
+    cdef ListHeader read_list_begin(self): pass
+    cdef void read_list_end(self): pass
+
+    # Messages
+
+    cdef MessageHeader read_message_begin(self): pass
+    cdef void read_message_end(self): pass
+
+
 cdef class Protocol(object):
     """Base class for all protocol implementations.
 

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -73,7 +73,7 @@ cdef class MessageHeader(object):
 
     def __str__(self):
         return 'MessageHeader(%r, %r, %r)' % (
-            self.name, self.seqid, mtype.name_of(self.type)
+            self.name, self.seqid, ttype.name_of(self.type)
         )
 
     def __repr__(self):
@@ -108,42 +108,47 @@ cdef class ProtocolWriter(object):
 
 cdef class ProtocolReader:
 
-    # Helpers
+    # Skip
 
-    cdef void skip(self, int typ): pass
+    cdef void skip(self, int typ) except *: pass
+    cdef void skip_binary(self) except *: pass
+    cdef void skip_map(self) except *: pass
+    cdef void skip_list(self) except *: pass
+    cdef void skip_set(self) except *: pass
+    cdef void skip_struct(self) except *: pass
 
     # Primitives
 
-    cdef bint read_bool(self): pass
-    cdef int8_t read_byte(self): pass
-    cdef double read_double(self): pass
-    cdef int16_t read_i16(self): pass
-    cdef int32_t read_i32(self): pass
-    cdef int64_t read_i64(self): pass
+    cdef bint read_bool(self) except *: pass
+    cdef int8_t read_byte(self) except *: pass
+    cdef double read_double(self) except *: pass
+    cdef int16_t read_i16(self) except *: pass
+    cdef int32_t read_i32(self) except *: pass
+    cdef int64_t read_i64(self) except *: pass
     cdef bytes read_binary(self): pass
 
     # Structs
 
-    cdef void read_struct_begin(self): pass
+    cdef void read_struct_begin(self) except *: pass
     cdef FieldHeader read_field_begin(self): pass
-    cdef void read_field_end(self): pass
-    cdef void read_struct_end(self): pass
+    cdef void read_field_end(self) except *: pass
+    cdef void read_struct_end(self) except *: pass
 
     # Containers
 
     cdef MapHeader read_map_begin(self): pass
-    cdef void read_map_end(self): pass
+    cdef void read_map_end(self) except *: pass
 
     cdef SetHeader read_set_begin(self): pass
-    cdef void read_set_end(self): pass
+    cdef void read_set_end(self) except *: pass
 
     cdef ListHeader read_list_begin(self): pass
-    cdef void read_list_end(self): pass
+    cdef void read_list_end(self) except *: pass
 
     # Messages
 
     cdef MessageHeader read_message_begin(self): pass
-    cdef void read_message_end(self): pass
+    cdef void read_message_end(self) except *: pass
 
 
 cdef class Protocol(object):
@@ -154,6 +159,9 @@ cdef class Protocol(object):
         Removed ``dumps`` and ``loads`` methods and added
         ``serialize_message`` and ``deserialize_message``.
     """
+
+    cpdef ProtocolReader reader(self, ReadBuffer buff):
+        raise NotImplementedError
 
     cpdef ProtocolWriter writer(self, WriteBuffer buff):
         raise NotImplementedError

--- a/thriftrw/spec/base.pxd
+++ b/thriftrw/spec/base.pxd
@@ -21,13 +21,15 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 
 cdef class TypeSpec(object):
 
     cpdef Value to_wire(TypeSpec self, object value)
 
     cpdef object from_wire(TypeSpec self, Value wire_value)
+
+    cpdef object read_from(TypeSpec self, ProtocolReader reader)
 
     cpdef void write_to(TypeSpec self, ProtocolWriter writer,
                         object value) except *

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -61,6 +61,7 @@ cdef class TypeSpec(object):
 
     cpdef void write_to(TypeSpec self, ProtocolWriter writer,
                         object value) except *:
+        """Writes a value directly to :py:class:`thriftrw.protocol.ProtocolWriter`."""
         writer.write_value(self.to_wire(value))
 
     cpdef Value to_wire(TypeSpec self, object value):

--- a/thriftrw/spec/base.pyx
+++ b/thriftrw/spec/base.pyx
@@ -21,12 +21,12 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 
 __all__ = ['TypeSpec']
 
 
-cdef class TypeSpec(object):
+cdef class TypeSpec:
     """Base class for classes representing TypeSpecs.
 
     A TypeSpec knows how to convert values of the corresponding type to and
@@ -58,6 +58,10 @@ cdef class TypeSpec(object):
 
         def __get__(self):
             raise NotImplementedError
+
+    cpdef object read_from(TypeSpec self, ProtocolReader reader):
+        """Read a primitive value of this type from :py:class:`thriftrw.protocol.ProtocolReader`."""
+        raise NotImplementedError
 
     cpdef void write_to(TypeSpec self, ProtocolWriter writer,
                         object value) except *:

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -25,7 +25,7 @@ from collections import defaultdict
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport I32Value, Value
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 from .base cimport TypeSpec
 from . cimport check
 
@@ -135,6 +135,9 @@ cdef class EnumTypeSpec(TypeSpec):
             self.linked = True
             self.surface = enum_cls(self, scope)
         return self
+
+    cpdef object read_from(EnumTypeSpec self, ProtocolReader reader):
+        return reader.read_i32()
 
     cpdef Value to_wire(self, object value):
         return I32Value(value)

--- a/thriftrw/spec/field.pyx
+++ b/thriftrw/spec/field.pyx
@@ -85,7 +85,7 @@ cdef class FieldSpec(object):
         return self
 
     @property
-    def ttype_code(self):
+    def ttype_code(FieldSpec self):
         return self.spec.ttype_code
 
     @classmethod

--- a/thriftrw/spec/list.pyx
+++ b/thriftrw/spec/list.pyx
@@ -26,7 +26,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport ListValue
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport ListHeader, ProtocolWriter
+from thriftrw.protocol.core cimport ListHeader, ProtocolWriter, ProtocolReader
 
 __all__ = ['ListTypeSpec']
 
@@ -60,6 +60,15 @@ cdef class ListTypeSpec(TypeSpec):
     @property
     def name(self):
         return 'list<%s>' % self.vspec.name
+
+    cpdef object read_from(ListTypeSpec self, ProtocolReader reader):
+        cdef ListHeader header = reader.read_list_begin()
+        cdef list output = []
+        for i in range(header.size):
+            output.append(self.vspec.read_from(reader))
+
+        reader.read_list_end()
+        return output
 
     cpdef Value to_wire(ListTypeSpec self, object value):
         return ListValue(

--- a/thriftrw/spec/map.pyx
+++ b/thriftrw/spec/map.pyx
@@ -25,7 +25,7 @@ from .base cimport TypeSpec
 from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport MapItem, MapValue, Value
-from thriftrw.protocol.core cimport MapHeader, ProtocolWriter
+from thriftrw.protocol.core cimport MapHeader, ProtocolWriter, ProtocolReader
 
 __all__ = ['MapTypeSpec']
 
@@ -82,6 +82,15 @@ cdef class MapTypeSpec(TypeSpec):
             self.kspec.to_primitive(k): self.vspec.to_primitive(v)
             for k, v in value.items()
         }
+
+    cpdef object read_from(MapTypeSpec self, ProtocolReader reader):
+        cdef MapHeader header = reader.read_map_begin()
+        cdef dict output = {
+            self.kspec.read_from(reader): self.vspec.read_from(reader)
+            for i in range(header.size)
+        }
+        reader.read_map_end()
+        return output
 
     cpdef void write_to(MapTypeSpec self, ProtocolWriter writer,
                         object value) except *:

--- a/thriftrw/spec/primitive.pxd
+++ b/thriftrw/spec/primitive.pxd
@@ -27,7 +27,7 @@ from .base cimport TypeSpec
 
 cdef class PrimitiveTypeSpec(TypeSpec):
     cdef readonly str name
-    cdef readonly int8_t ttype_code
+    cdef readonly int8_t code
     cdef readonly object value_cls
     cdef readonly object surface
     cdef readonly object cast

--- a/thriftrw/spec/primitive.pxd
+++ b/thriftrw/spec/primitive.pxd
@@ -27,7 +27,7 @@ from .base cimport TypeSpec
 
 cdef class PrimitiveTypeSpec(TypeSpec):
     cdef readonly str name
-    cdef readonly int8_t code
+    cdef readonly int8_t ttype_code
     cdef readonly object value_cls
     cdef readonly object surface
     cdef readonly object cast

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -72,6 +72,10 @@ cdef class PrimitiveTypeSpec(TypeSpec):
         they have the correct type.
     """
 
+    @property
+    def ttype_code(self):
+        return self.code
+
     cpdef Value to_wire(self, object value):
         return self.value_cls(self.cast(value))
 
@@ -254,7 +258,7 @@ cdef class _ByteTypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('byte')
-        self.ttype_code = ttype.BYTE
+        self.code = ttype.BYTE
         self.value_cls = ByteValue
         self.surface = _INTEGRAL
         self.cast = int
@@ -273,7 +277,7 @@ cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('double')
-        self.ttype_code = ttype.DOUBLE
+        self.code = ttype.DOUBLE
         self.value_cls = DoubleValue
         self.surface = _FLOATING
         self.cast = float
@@ -291,7 +295,7 @@ cdef class _I16TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('i16')
-        self.ttype_code = ttype.I16
+        self.code = ttype.I16
         self.value_cls = I16Value
         self.surface = _INTEGRAL
         self.cast = int
@@ -310,7 +314,7 @@ cdef class _I32TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('i32')
-        self.ttype_code = ttype.I32
+        self.code = ttype.I32
         self.value_cls = I32Value
         self.surface = _INTEGRAL
         self.cast = int
@@ -329,7 +333,7 @@ cdef class _I64TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str("i64")
-        self.ttype_code = ttype.I64
+        self.code = ttype.I64
         self.value_cls = I64Value
         self.surface = _INTEGRAL
         self.cast = long

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -120,6 +120,8 @@ cdef class _TextualTypeSpec(TypeSpec):
 
     cpdef void write_to(_TextualTypeSpec self, ProtocolWriter writer,
                         object value) except *:
+        if isinstance(value, unicode):
+            value = value.encode('utf-8')
         writer.write_binary(bytes(value))
 
     cpdef void validate(_TextualTypeSpec self, object instance) except *:

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -72,10 +72,6 @@ cdef class PrimitiveTypeSpec(TypeSpec):
         they have the correct type.
     """
 
-    @property
-    def ttype_code(self):
-        return self.code
-
     cpdef Value to_wire(self, object value):
         return self.value_cls(self.cast(value))
 
@@ -139,7 +135,7 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
     name = str('string')
     surface = unicode
 
-    cpdef unicode read_from(_TextTypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_TextTypeSpec self, ProtocolReader reader):
         # TODO: Is this right?
         return unicode(reader.read_binary())
 
@@ -169,7 +165,7 @@ cdef class _BinaryTypeSpec(_TextualTypeSpec):
     name = str('binary')
     surface = bytes
 
-    cpdef bytes read_from(_BinaryTypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_BinaryTypeSpec self, ProtocolReader reader):
         return reader.read_binary()
 
     cpdef object to_primitive(_BinaryTypeSpec self, object value):
@@ -199,7 +195,7 @@ cdef class _BoolTypeSpec(TypeSpec):
     surface = bool
     ttype_code = ttype.BOOL
 
-    cpdef bint read_from(_BoolTypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_BoolTypeSpec self, ProtocolReader reader):
         return reader.read_bool()
 
     cpdef Value to_wire(_BoolTypeSpec self, object value):
@@ -256,7 +252,7 @@ cdef class _ByteTypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('byte')
-        self.code = ttype.BYTE
+        self.ttype_code = ttype.BYTE
         self.value_cls = ByteValue
         self.surface = _INTEGRAL
         self.cast = int
@@ -266,7 +262,7 @@ cdef class _ByteTypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_byte(value)
 
-    cpdef int read_from(_ByteTypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_ByteTypeSpec self, ProtocolReader reader):
         return reader.read_byte()
 
 ByteTypeSpec = _ByteTypeSpec()
@@ -275,7 +271,7 @@ cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('double')
-        self.code = ttype.DOUBLE
+        self.ttype_code = ttype.DOUBLE
         self.value_cls = DoubleValue
         self.surface = _FLOATING
         self.cast = float
@@ -284,7 +280,7 @@ cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_double(value)
 
-    cpdef double read_from(_DoubleTypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_DoubleTypeSpec self, ProtocolReader reader):
         return reader.read_double()
 
 DoubleTypeSpec = _DoubleTypeSpec()
@@ -293,7 +289,7 @@ cdef class _I16TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('i16')
-        self.code = ttype.I16
+        self.ttype_code = ttype.I16
         self.value_cls = I16Value
         self.surface = _INTEGRAL
         self.cast = int
@@ -303,7 +299,7 @@ cdef class _I16TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i16(value)
 
-    cpdef int read_from(_I16TypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_I16TypeSpec self, ProtocolReader reader):
         return reader.read_i16()
 
 I16TypeSpec = _I16TypeSpec()
@@ -312,7 +308,7 @@ cdef class _I32TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str('i32')
-        self.code = ttype.I32
+        self.ttype_code = ttype.I32
         self.value_cls = I32Value
         self.surface = _INTEGRAL
         self.cast = int
@@ -322,7 +318,7 @@ cdef class _I32TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i32(value)
 
-    cpdef int read_from(_I32TypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_I32TypeSpec self, ProtocolReader reader):
         return reader.read_i32()
 
 I32TypeSpec = _I32TypeSpec()
@@ -331,7 +327,7 @@ cdef class _I64TypeSpec(PrimitiveTypeSpec):
 
     def __init__(self):
         self.name = str("i64")
-        self.code = ttype.I64
+        self.ttype_code = ttype.I64
         self.value_cls = I64Value
         self.surface = _INTEGRAL
         self.cast = long
@@ -341,7 +337,7 @@ cdef class _I64TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i64(value)
 
-    cpdef int read_from(_I64TypeSpec self, ProtocolReader reader) except *:
+    cpdef object read_from(_I64TypeSpec self, ProtocolReader reader):
         return reader.read_i64()
 
 I64TypeSpec = _I64TypeSpec()

--- a/thriftrw/spec/primitive.pyx
+++ b/thriftrw/spec/primitive.pyx
@@ -25,7 +25,7 @@ import decimal
 import fractions
 
 from thriftrw.wire cimport ttype
-from thriftrw.protocol.core cimport ProtocolWriter
+from thriftrw.protocol.core cimport ProtocolWriter, ProtocolReader
 from thriftrw.wire.value cimport (
     Value,
     BoolValue,
@@ -139,6 +139,10 @@ cdef class _TextTypeSpec(_TextualTypeSpec):
     name = str('string')
     surface = unicode
 
+    cpdef unicode read_from(_TextTypeSpec self, ProtocolReader reader) except *:
+        # TODO: Is this right?
+        return unicode(reader.read_binary())
+
     cpdef object to_primitive(_TextTypeSpec self, object value):
         if isinstance(value, bytes):
             value = value.decode('utf-8')
@@ -164,6 +168,9 @@ cdef class _BinaryTypeSpec(_TextualTypeSpec):
 
     name = str('binary')
     surface = bytes
+
+    cpdef bytes read_from(_BinaryTypeSpec self, ProtocolReader reader) except *:
+        return reader.read_binary()
 
     cpdef object to_primitive(_BinaryTypeSpec self, object value):
         if isinstance(value, unicode):
@@ -191,6 +198,9 @@ cdef class _BoolTypeSpec(TypeSpec):
     name = str('bool')
     surface = bool
     ttype_code = ttype.BOOL
+
+    cpdef bint read_from(_BoolTypeSpec self, ProtocolReader reader) except *:
+        return reader.read_bool()
 
     cpdef Value to_wire(_BoolTypeSpec self, object value):
         return BoolValue(bool(value))
@@ -256,6 +266,9 @@ cdef class _ByteTypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_byte(value)
 
+    cpdef int read_from(_ByteTypeSpec self, ProtocolReader reader) except *:
+        return reader.read_byte()
+
 ByteTypeSpec = _ByteTypeSpec()
 
 cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
@@ -270,6 +283,9 @@ cdef class _DoubleTypeSpec(PrimitiveTypeSpec):
     cpdef void write_to(_DoubleTypeSpec self, ProtocolWriter writer,
                         object value) except *:
         writer.write_double(value)
+
+    cpdef double read_from(_DoubleTypeSpec self, ProtocolReader reader) except *:
+        return reader.read_double()
 
 DoubleTypeSpec = _DoubleTypeSpec()
 
@@ -287,6 +303,9 @@ cdef class _I16TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i16(value)
 
+    cpdef int read_from(_I16TypeSpec self, ProtocolReader reader) except *:
+        return reader.read_i16()
+
 I16TypeSpec = _I16TypeSpec()
 
 cdef class _I32TypeSpec(PrimitiveTypeSpec):
@@ -303,6 +322,9 @@ cdef class _I32TypeSpec(PrimitiveTypeSpec):
                         object value) except *:
         writer.write_i32(value)
 
+    cpdef int read_from(_I32TypeSpec self, ProtocolReader reader) except *:
+        return reader.read_i32()
+
 I32TypeSpec = _I32TypeSpec()
 
 cdef class _I64TypeSpec(PrimitiveTypeSpec):
@@ -318,6 +340,9 @@ cdef class _I64TypeSpec(PrimitiveTypeSpec):
     cpdef void write_to(_I64TypeSpec self, ProtocolWriter writer,
                         object value) except *:
         writer.write_i64(value)
+
+    cpdef int read_from(_I64TypeSpec self, ProtocolReader reader) except *:
+        return reader.read_i64()
 
 I64TypeSpec = _I64TypeSpec()
 

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -25,7 +25,7 @@ from thriftrw.wire cimport ttype
 from thriftrw._cython cimport richcompare
 from thriftrw.wire.value cimport SetValue
 from thriftrw.wire.value cimport Value
-from thriftrw.protocol.core cimport SetHeader, ProtocolWriter
+from thriftrw.protocol.core cimport SetHeader, ProtocolWriter, ProtocolReader
 from . cimport check
 
 __all__ = ['SetTypeSpec']
@@ -52,6 +52,15 @@ cdef class SetTypeSpec(TypeSpec):
     @property
     def name(self):
         return 'set<%s>' % self.vspec.name
+
+    cpdef object read_from(SetTypeSpec self, ProtocolReader reader):
+        cdef SetHeader header = reader.read_set_begin()
+        cdef set output = {
+            self.vspec.read_from for i in range(header.size)
+        }
+        reader.read_set_end()
+
+        return output
 
     cpdef Value to_wire(self, object value):
         items = []

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -56,7 +56,7 @@ cdef class SetTypeSpec(TypeSpec):
     cpdef object read_from(SetTypeSpec self, ProtocolReader reader):
         cdef SetHeader header = reader.read_set_begin()
         cdef set output = {
-            self.vspec.read_from for i in range(header.size)
+            self.vspec.read_from(reader) for i in range(header.size)
         }
         reader.read_set_end()
 

--- a/thriftrw/spec/set.pyx
+++ b/thriftrw/spec/set.pyx
@@ -55,9 +55,10 @@ cdef class SetTypeSpec(TypeSpec):
 
     cpdef object read_from(SetTypeSpec self, ProtocolReader reader):
         cdef SetHeader header = reader.read_set_begin()
-        cdef set output = {
-            self.vspec.read_from(reader) for i in range(header.size)
-        }
+        cdef set output = set()
+        for _ in range(header.size):
+            output.add(self.vspec.read_from(reader))
+
         reader.read_set_end()
 
         return output

--- a/thriftrw/spec/struct.pxd
+++ b/thriftrw/spec/struct.pxd
@@ -31,3 +31,4 @@ cdef class StructTypeSpec(TypeSpec):
     cdef public bint linked
     cdef public object surface
 
+    cdef dict _index

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -176,7 +176,7 @@ cdef class StructTypeSpec(TypeSpec):
         cdef FieldSpec spec
         cdef FieldHeader header = reader.read_field_begin()
 
-        while header.id != 0:
+        while header.type != -1:
             spec = self._index.get((header.id, header.type), None)
 
             # Unrecognized field--possibly different version of struct definition.

--- a/thriftrw/spec/union.pxd
+++ b/thriftrw/spec/union.pxd
@@ -33,4 +33,3 @@ cdef class UnionTypeSpec(TypeSpec):
     cdef public object surface
 
     cdef dict _index
-    cdef dict _read_from(UnionTypeSpec self, ProtocolReader reader)

--- a/thriftrw/spec/union.pxd
+++ b/thriftrw/spec/union.pxd
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 from .base cimport TypeSpec
+from thriftrw.protocol.core cimport ProtocolReader
 
 
 cdef class UnionTypeSpec(TypeSpec):
@@ -30,3 +31,6 @@ cdef class UnionTypeSpec(TypeSpec):
 
     cdef public bint linked
     cdef public object surface
+
+    cdef dict _index
+    cdef dict _read_from(UnionTypeSpec self, ProtocolReader reader)

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -159,9 +159,6 @@ cdef class UnionTypeSpec(TypeSpec):
         return cls(union.name, fields)
 
     cpdef read_from(UnionTypeSpec self, ProtocolReader reader):
-        return self.surface(**self._read_from(reader))
-
-    cdef dict _read_from(UnionTypeSpec self, ProtocolReader reader):
         reader.read_struct_begin()
 
         cdef dict kwargs = {}
@@ -171,7 +168,7 @@ cdef class UnionTypeSpec(TypeSpec):
         header = reader.read_field_begin()
 
         # We use a 0 attribute to signify struct end due to cython constraints.
-        while header.id != 0:
+        while header.type != -1:
             spec = self._index.get((header.id, header.type), None)
 
             # Unrecognized field--possibly different version of struct definition.
@@ -185,7 +182,7 @@ cdef class UnionTypeSpec(TypeSpec):
             header = reader.read_field_begin()
 
         reader.read_struct_end()
-        return kwargs
+        return self.surface(**kwargs)
 
     cpdef void write_to(UnionTypeSpec self, ProtocolWriter writer,
                         object struct) except *:


### PR DESCRIPTION
This is a preliminary PR. It's not passing tests for anything that uses the old *_value interface, which I need to restore (or migrate the tests, not sure).

1. The read_from struct loops is duplicated in service.pyx, struct.pyx, and union.pyx. To a lesser extent read_skip as well. So it'd be good to fix this.

2. Should the tests use the new ProtocolReader interface or the old deserialize_value one? Should we test both?

3. return None does not work as expected when the return value is defined as a python object; I'm using a sentinel value of type == -1 to signify STRUCT_END instead.