### PR TITLE
Fix input too short errors being ignored

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Releases
 ========
 
+1.5.1 (unreleased)
+------------------
+
+- Fixed a bug where errors while parsing certain parts of the Thrift payload
+  would be ignored.
+
 1.5.0 (2016-12-05)
 ------------------
 

--- a/thriftrw/protocol/binary.pyx
+++ b/thriftrw/protocol/binary.pyx
@@ -213,7 +213,7 @@ cdef class BinaryProtocolReader(ProtocolReader):
         cdef int32_t length = self._i32()
         self.reader.skip(length)
 
-    cdef FieldHeader read_field_begin(self):
+    cdef FieldHeader read_field_begin(self) except *:
         cdef int8_t field_type = self._byte()
         if field_type == STRUCT_END:
             return STRUCT_END_HEADER
@@ -222,20 +222,20 @@ cdef class BinaryProtocolReader(ProtocolReader):
 
         return FieldHeader(field_type, field_id)
 
-    cdef MapHeader read_map_begin(self):
+    cdef MapHeader read_map_begin(self) except *:
         cdef int8_t key_ttype = self._byte()
         cdef int8_t value_ttype = self._byte()
         cdef int32_t length = self._i32()
 
         return MapHeader(key_ttype, value_ttype, length)
 
-    cdef SetHeader read_set_begin(self):
+    cdef SetHeader read_set_begin(self) except *:
         cdef int8_t value_ttype = self._byte()
         cdef int32_t length = self._i32()
 
         return SetHeader(value_ttype, length)
 
-    cdef ListHeader read_list_begin(self):
+    cdef ListHeader read_list_begin(self) except *:
         cdef int8_t value_ttype = self._byte()
         cdef int32_t length = self._i32()
 

--- a/thriftrw/protocol/core.pxd
+++ b/thriftrw/protocol/core.pxd
@@ -122,19 +122,19 @@ cdef class ProtocolReader:
     # Structs
 
     cdef void read_struct_begin(self) except *
-    cdef FieldHeader read_field_begin(self)
+    cdef FieldHeader read_field_begin(self) except *
     cdef void read_field_end(self) except *
     cdef void read_struct_end(self) except *
 
     # Containers
 
-    cdef MapHeader read_map_begin(self)
+    cdef MapHeader read_map_begin(self) except *
     cdef void read_map_end(self) except *
 
-    cdef SetHeader read_set_begin(self)
+    cdef SetHeader read_set_begin(self) except *
     cdef void read_set_end(self) except *
 
-    cdef ListHeader read_list_begin(self)
+    cdef ListHeader read_list_begin(self) except *
     cdef void read_list_end(self) except *
 
     # Messages

--- a/thriftrw/protocol/core.pyx
+++ b/thriftrw/protocol/core.pyx
@@ -101,7 +101,7 @@ cdef class ProtocolReader:
     # Structs
 
     cdef void read_struct_begin(self) except *: pass
-    cdef FieldHeader read_field_begin(self):
+    cdef FieldHeader read_field_begin(self) except *:
         """Parse the next three bytes as a FieldHeader object.
 
         :return: FieldHeader with type and id set to -1 if a struct end is found.
@@ -112,13 +112,13 @@ cdef class ProtocolReader:
 
     # Containers
 
-    cdef MapHeader read_map_begin(self): pass
+    cdef MapHeader read_map_begin(self) except *: pass
     cdef void read_map_end(self) except *: pass
 
-    cdef SetHeader read_set_begin(self): pass
+    cdef SetHeader read_set_begin(self) except *: pass
     cdef void read_set_end(self) except *: pass
 
-    cdef ListHeader read_list_begin(self): pass
+    cdef ListHeader read_list_begin(self) except *: pass
     cdef void read_list_end(self) except *: pass
 
     # Messages


### PR DESCRIPTION
The `read_field_begin`, `read_map_begin`, `read_set_begin` and
`read_list_begin` methods of `ProtocolReader` return `cdef struct`s
(which translate to plain C structs) for performance reasons.
Unfortunately, that means that the generated C code does not know
whether an exception occurred while running those functions.

To fix this, we need to add an `except *` clause to these methods so
that cython generates code to check for exceptions and propagate them.

Before, `BinaryProtocolReader.read_field_begin` generated the following
section at the end,

```c
   /* function exit code */
  __pyx_L1_error:;
  __Pyx_WriteUnraisable("thriftrw.protocol.binary.BinaryProtocolReader.read_field_begin", __pyx_clineno, __pyx_lineno, __pyx_filename, 0, 0);
  __pyx_L0:;
  __Pyx_RefNannyFinishContext();
  return __pyx_r;
```

With this change, it generates,

```c
  /* function exit code */
  __pyx_L1_error:;
  __Pyx_AddTraceback("thriftrw.protocol.binary.BinaryProtocolReader.read_field_begin", __pyx_clineno, __pyx_lineno, __pyx_filename);
  __pyx_L0:;
  __Pyx_RefNannyFinishContext();
  return __pyx_r;
```

Note that the `__Pyx_WriteUnraisable` turned to `__Pyx_AddTraceback`.

---

Minor note about testing:

While investigating this, a bug was discovered in the test for the error
path. It is supposed to exercise the error on two code paths but instead
of doing,

    with pytest.raises(...):
        # code path 1

    with pytest.raises(...):
        # code path 2

The test was doing,

    with pytest.raises(...):
        # code path 1
        # code path 2

Which meant that the second code path wasn't actually exercised.