### PR TITLE
travis: Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
     - {python: 3.6, env: TOX_ENV=py36}
     - {python: pypy, env: TOX_ENV=pypy}
     - {python: pypy3, env: TOX_ENV=pypy3}
-    - {python: pypy3, env: TOX_ENV=pypy3}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,19 @@ sudo: false
 
 language: python
 
-env:
-    - TOX_ENV=py27
-    - TOX_ENV=py33
-    - TOX_ENV=py34
-    - TOX_ENV=pypy
-    - TOX_ENV=cover
-    - TOX_ENV=flake8
-    - TOX_ENV=docs
-
 matrix:
-    include:
-        # Python 3.5 needs to be explicitly requested with python: for now.
-        # See travis-ci/travis-ci#4794 and travis-ci/travis-ci#521.
-        - python: 3.5
-          env:
-              - TOX_ENV=py35
-
+  include:
+    - {python: 2.7, env: TOX_ENV=py27}
+    - {python: 3.3, env: TOX_ENV=py33}
+    - {python: 3.4, env: TOX_ENV=py34}
+    - {python: 3.5, env: TOX_ENV=py35}
+    - {python: 3.6, env: TOX_ENV=py36}
+    - {python: pypy, env: TOX_ENV=pypy}
+    - {python: pypy3, env: TOX_ENV=pypy3}
+    - {python: pypy3, env: TOX_ENV=pypy3}
+    - {env: TOX_ENV=cover}
+    - {env: TOX_ENV=flake8}
+    - {env: TOX_ENV=docs}
 
 install:
     - pip install tox

--- a/tests/spec/test_union.py
+++ b/tests/spec/test_union.py
@@ -123,14 +123,14 @@ def test_load(loads):
         1: binary b
         2: optional string s
         3: optional i32 i
-        4: list<Foo> l
+        4: list<Foo> ls
     }''').Foo
     spec = Foo.type_spec
 
     bfoo = Foo(b=b'foo')
     sfoo = Foo(s='bar')
     ifoo = Foo(i=42)
-    lfoo = Foo(l=[bfoo, sfoo, ifoo])
+    lfoo = Foo(ls=[bfoo, sfoo, ifoo])
 
     cases = [
         (
@@ -158,7 +158,7 @@ def test_load(loads):
                     vstruct((3, ttype.I32, vi32(42))),
                 ))
             ),
-            {'l': [
+            {'ls': [
                 {'b': b'foo'},
                 {'s': u'bar'},
                 {'i': 42},

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
     pypy: pypy
     pypy3: pypy3
 deps = -rrequirements-test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,cover,flake8,docs
+envlist = py27,py33,py34,py35,py36,pypy,pypy3,cover,flake8,docs
 usedevelop = true
 
 [testenv]


### PR DESCRIPTION
This changes our Travis setup to explicitly request all relevant
versions of Python for each tox run.

This also fixes a lint issue that newer versions of flake8 complain
about.