### PR TITLE
FunctionResultSpec: Fix unexpected return segfault

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Releases
 
 - Fixed a bug where errors while parsing certain parts of the Thrift payload
   would be ignored.
+- Fixed a bug that caused a segfault if a return value was received for a
+  ``void`` function.
 
 1.5.0 (2016-12-05)
 ------------------

--- a/tests/spec/test_service.py
+++ b/tests/spec/test_service.py
@@ -395,3 +395,21 @@ def test_service_spec_lookup(loads):
     assert service_spec.lookup('foo') is m.S.foo.spec
     assert service_spec.lookup('bar') is m.S.bar.spec
     assert service_spec.lookup('baz') is None
+
+
+def test_return_value_from_the_future(loads):
+    new_m = loads('''
+        struct Res {
+            1: optional string message
+        }
+
+        service S { Res foo() }
+    ''')
+
+    res = new_m.S.foo.response(success=new_m.Res(message="foo"))
+    payload = new_m.dumps(res)
+
+    old_m = loads('''service S { void foo() }''')
+    assert (
+        old_m.loads(old_m.S.foo.response, payload) == old_m.S.foo.response()
+    )

--- a/thriftrw/spec/service.pyx
+++ b/thriftrw/spec/service.pyx
@@ -189,17 +189,20 @@ cdef class FunctionResultSpec(UnionTypeSpec):
         while header.type != -1:
             spec = self._index.get((header.id, header.type), None)
 
-            if spec is None and header.id != 0:
-                raise UnknownExceptionError(
-                    (
-                        '"%s" received an unrecognized exception. '
-                        'Make sure your Thrift IDL is up-to-date with '
-                        'what the remote host is using.'
-                    ) % self.name,
-                )
-
-            val = spec.spec.read_from(reader)
-            kwargs[spec.name] = val
+            if spec is None:
+                if header.id != 0:
+                    raise UnknownExceptionError(
+                        (
+                            '"%s" received an unrecognized exception. '
+                            'Make sure your Thrift IDL is up-to-date with '
+                            'what the remote host is using.'
+                        ) % self.name,
+                    )
+                else:
+                    reader.skip(header.type)
+            else:
+                val = spec.spec.read_from(reader)
+                kwargs[spec.name] = val
 
             reader.read_field_end()
             header = reader.read_field_begin()


### PR DESCRIPTION
There was a bug in FunctionResultSpec which caused a segfault if it
received a return value where none was expected.

Ref: T1295887