### PR TITLE
Implement __hash__ on struct and union types

### DIFF
--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -484,6 +484,15 @@ def test_default_value_type_mismatches(loads, expr):
     )
 
 
+def test_has_thrift_module(loads):
+    module = loads('''
+        struct Foo {
+            1: required string a
+        }
+    ''')
+    assert module is module.Foo.__thrift_module__
+
+
 def test_has_implemented_hash(loads):
     module = loads('''
         struct Foo {

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -484,10 +484,22 @@ def test_default_value_type_mismatches(loads, expr):
     )
 
 
-def test_has_thrift_module(loads):
+def test_has_implemented_hash(loads):
     module = loads('''
         struct Foo {
             1: required string a
         }
     ''')
-    assert module is module.Foo.__thrift_module__
+    assert hasattr(module.Foo, '__hash__')
+
+
+def test_hash_ignores_non_hashable_types(loads):
+    module = loads('''
+        struct Foo {
+            1: required string a
+            2: required list<string> b = []
+            3: required map<string, string> c = {}
+        }
+    ''')
+    test = module.Foo(a='foo', b=['bar'], c={'foo': 'bar'})
+    assert hash(test)

--- a/tests/spec/test_union.py
+++ b/tests/spec/test_union.py
@@ -221,3 +221,25 @@ def test_has_thrift_module(loads):
         2: string s
     }''')
     assert module is module.Foo.__thrift_module__
+
+
+def test_has_implemented_hash(loads):
+    module = loads('''
+        union Foo {
+            1: binary b
+            2: string s
+        }
+    ''')
+    assert hasattr(module.Foo, '__hash__')
+
+
+def test_hash_ignores_non_hashable_types(loads):
+    module = loads('''
+        union Foo {
+            1: binary b
+            2: string s
+            3: list<string> ls
+        }
+    ''')
+    test = module.Foo(s='bar')
+    assert hash(test)

--- a/thriftrw/spec/common.pyx
+++ b/thriftrw/spec/common.pyx
@@ -48,8 +48,9 @@ def fields_hash(fields):
         return True
 
     def __hash__(self):
-        return hash(tuple([getattr(self, field) for field in fields if hashable(field)]))
+        return hash(tuple([getattr(self, field) for field in fields if hashable(getattr(self, field))]))
 
+    return __hash__
 
 def fields_str(cls_name, field_list, include_none=True):
     """Generates a ``__str__`` method.

--- a/thriftrw/spec/common.pyx
+++ b/thriftrw/spec/common.pyx
@@ -34,6 +34,23 @@ def fields_eq(fields):
     return __eq__
 
 
+def fields_hash(fields):
+    """Generates an ``__hash__`` method.
+
+    :param list fields:
+        List of fields of the object to be hashed.
+    """
+    def hashable(obj):
+        try:
+            hash(obj)
+        except TypeError:
+            return False
+        return True
+
+    def __hash__(self):
+        return hash(tuple([getattr(self, field) for field in fields if hashable(field)]))
+
+
 def fields_str(cls_name, field_list, include_none=True):
     """Generates a ``__str__`` method.
 

--- a/thriftrw/spec/struct.pyx
+++ b/thriftrw/spec/struct.pyx
@@ -517,7 +517,6 @@ def struct_cls(struct_spec, scope):
         required_fields,
         list(zip(optional_fields, field_defaults)),
     )
-
-    # TODO generate a reasonable docstring for the class too.
+    struct_dct['__hash__'] = common.fields_hash(field_names)
 
     return type(str(struct_spec.name), (struct_spec.base_cls,), struct_dct)

--- a/thriftrw/spec/union.pyx
+++ b/thriftrw/spec/union.pyx
@@ -409,5 +409,6 @@ def union_cls(union_spec, scope):
     union_dct['__doc__'] = union_docstring(
         union_spec.name, field_names
     )
+    union_dct['__hash__'] = common.fields_hash(field_names)
 
     return type(str(union_spec.name), (object,), union_dct)


### PR DESCRIPTION
It looks like when generating Python classes, we are not generating `__hash__` on the `struct` or `union` types. This prevents the generated classes from being used in `set()` when in Python 3.

This generates a `__hash__` function that hashes all hashable fields in the class.

Fixes #141