### PR TITLE
Remove python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 matrix:
   include:
     - {python: 2.7, env: TOX_ENV=py27}
-    - {python: 3.3, env: TOX_ENV=py33}
     - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy,pypy3,cover,flake8,docs
+envlist = py27,py34,py35,py36,pypy,pypy3,cover,flake8,docs
 usedevelop = true
 
 [testenv]
@@ -8,7 +8,6 @@ commands =
     py.test -svv tests
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
This removes python 3.3 which has been EOL as of 2017-09-29.

https://devguide.python.org/#status-of-python-branches