### PR TITLE
Support python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
-    - {python: 3.7, env: TOX_ENV=py37, dist: xenial, sudo: true}
+    - {python: 3.7, env: TOX_ENV=py37, dist: xenial}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
+    - {python: 3.7, env: TOX_ENV=py37}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ matrix:
     - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
-    - {python: 3.7, env: TOX_ENV=py37, dist: xenial}
+    # Need sudo here to actually get xenial.
+    # See https://github.com/travis-ci/travis-ci/issues/9815
+    - {python: 3.7, env: TOX_ENV=py37, dist: xenial, sudo: true}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
-    - {python: 3.7, env: TOX_ENV=py37}
+    - {python: 3.7, env: TOX_ENV=py37, dist: xenial, sudo: true}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
 
 install:
     - pip install tox
-    - pip install 'cython>=0.23,<0.24'
+    - pip install cython
 script:
     - tox -e $TOX_ENV

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cython>=0.23,<0.24
+cython
 six
 ply

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,cover,flake8,docs
+envlist = py27,py34,py35,py36,py37,cover,flake8,docs
 usedevelop = true
 
 [testenv]
@@ -11,6 +11,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps = -rrequirements-test.txt
 
 [testenv:cover]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
 deps =
     -rrequirements-test.txt
     coveralls
-    cython>=0.23,<0.24
+    cython
 commands =
     python setup.py clean --all build_ext --force --inplace
     py.test --cov thriftrw --cov-config .coveragerc --cov-report=xml --cov-report=term-missing tests


### PR DESCRIPTION
Based on the cython documentation, supporting python 3.7 requires updating cython (the enum issue mentioned in 57994007 seems to be resolved) and rebuilding the cython c code which is done automatically when making a new release.  The c code is gitignored from the repository.

Fixes #147 