### PR TITLE
Support string enum values in from_primitive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Releases
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for string enums in from_primitive.
 
 
 1.6.0 (2018-08-20)

--- a/tests/spec/test_enum.py
+++ b/tests/spec/test_enum.py
@@ -107,6 +107,13 @@ def test_to_wire(loads):
     assert spec.to_wire(Enum.C) == vi32(-42)
 
 
+def test_enum_names(loads):
+    Enum = loads('enum RoundTripEnum { A = 2, B = 3, C = -42 }').RoundTripEnum
+    spec = Enum.type_spec
+
+    assert spec.from_primitive('A') == Enum.A
+
+
 def test_round_trip(loads):
     Enum = loads('enum RoundTripEnum { A = 2, B = 3, C = -42 }').RoundTripEnum
     spec = Enum.type_spec
@@ -126,6 +133,8 @@ def test_validate(loads):
 
     with pytest.raises(ValueError):
         Enum.type_spec.validate(4)
+
+    Enum.type_spec.validate('A')
 
 
 def test_enums_are_constants(loads):

--- a/tests/spec/test_enum.py
+++ b/tests/spec/test_enum.py
@@ -134,8 +134,6 @@ def test_validate(loads):
     with pytest.raises(ValueError):
         Enum.type_spec.validate(4)
 
-    Enum.type_spec.validate('A')
-
 
 def test_enums_are_constants(loads):
     mod = loads('''

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -153,13 +153,19 @@ cdef class EnumTypeSpec(TypeSpec):
         writer.write_i32(value)
 
     cpdef object from_primitive(self, object prim_value):
+        val = self.items.get(prim_value)
+        if val is not None:
+            return val
         return prim_value
 
     cpdef void validate(self, object instance) except *:
-        if instance not in self.values_to_names:
-            raise ValueError(
-                '%r is not a valid value for enum "%s"' % (instance, self.name)
-            )
+        if instance in self.values_to_names:
+            return
+        if instance in self.items:
+            return
+        raise ValueError(
+            '%r is not a valid value for enum "%s"' % (instance, self.name)
+        )
 
     @classmethod
     def compile(cls, enum):

--- a/thriftrw/spec/enum.pyx
+++ b/thriftrw/spec/enum.pyx
@@ -159,13 +159,10 @@ cdef class EnumTypeSpec(TypeSpec):
         return prim_value
 
     cpdef void validate(self, object instance) except *:
-        if instance in self.values_to_names:
-            return
-        if instance in self.items:
-            return
-        raise ValueError(
-            '%r is not a valid value for enum "%s"' % (instance, self.name)
-        )
+        if instance not in self.values_to_names:
+            raise ValueError(
+                '%r is not a valid value for enum "%s"' % (instance, self.name)
+            )
 
     @classmethod
     def compile(cls, enum):


### PR DESCRIPTION
This adds support for reading enum values as strings. Mainly added to be able to read json marshalled from thriftrw-go, which uses strings for enums.

Resolved #56 