### PR TITLE
Support enums from the future

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Releases
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed bug which caused unrecognized enums to throw exceptions.
 
 
 1.7.0 (2018-10-25)

--- a/tests/spec/test_const.py
+++ b/tests/spec/test_const.py
@@ -159,17 +159,16 @@ def test_duplicate_constant(loads):
     assert 'name is already taken' in str(exc_info)
 
 
-def test_invalid_enum(loads):
-    with pytest.raises(ThriftCompilerError) as exc_info:
-        loads('''
-            enum Foo {
-                A, B, C
-            }
+def test_enum_from_future_is_allowed(loads):
+    m = loads('''
+        enum Foo {
+            A, B, C
+        }
 
-            const Foo foo = 3
-        ''')
+        const Foo foo = 3
+    ''')
 
-    assert 'Value for constant "foo" is not valid' in str(exc_info)
+    assert 3 == m.foo
 
 
 def test_set_is_transformed(loads):


### PR DESCRIPTION
Despite our internal documentation and communications stating otherwise,
we weren't handling unrecognized enum values correctly. Validation would
fail on unrecognized enum values.

This change fixes this behavior by allowing enum values from the future.

Ref: T2223161