### PR TITLE
setup.py: Don't check cython version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Releases
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed a bug in setup.py that caused failures if the version of Cython being
+  used was a pre-release or a post-release.
 
 
 1.7.1 (2018-11-12)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cython
+cython>=0.17.0
 six
 ply

--- a/setup.py
+++ b/setup.py
@@ -49,45 +49,43 @@ Extension = None
 try:
     import Cython.Distutils
 
-    # from __future__ import absolute_import needs cython >= 0.17
-    if tuple(int(v) for v in Cython.__version__.split('.')) >= (0, 17, 0):
-        cmdclass.update(build_ext=Cython.Distutils.build_ext)
+    cmdclass.update(build_ext=Cython.Distutils.build_ext)
 
-        # Check if we forgot to add something to cython_modules.
-        for root, _, files in os.walk('thriftrw'):
-            for name in files:
-                if not name.endswith('.pyx'):
-                    continue
-                path = os.path.join(root, name)
-                module = path.replace('/', '.')[:-4]
-                if module not in cython_modules:
-                    raise Exception(
-                        'Module "%s" (%s) is not present in the '
-                        '"cython_modules" list.'
-                        % (module, path)
-                    )
+    # Check if we forgot to add something to cython_modules.
+    for root, _, files in os.walk('thriftrw'):
+        for name in files:
+            if not name.endswith('.pyx'):
+                continue
+            path = os.path.join(root, name)
+            module = path.replace('/', '.')[:-4]
+            if module not in cython_modules:
+                raise Exception(
+                    'Module "%s" (%s) is not present in the '
+                    '"cython_modules" list.'
+                    % (module, path)
+                )
 
-        Extension = Cython.Distutils.Extension
-        extension_filetype = '.pyx'
+    Extension = Cython.Distutils.Extension
+    extension_filetype = '.pyx'
 
-        cython_directives = {
-            'embedsignature': True,
-        }
+    cython_directives = {
+        'embedsignature': True,
+    }
 
-        if os.getenv('THRIFTRW_PROFILE'):
-            # Add hooks for the profiler in the generated C code.
-            cython_directives['profile'] = True
+    if os.getenv('THRIFTRW_PROFILE'):
+        # Add hooks for the profiler in the generated C code.
+        cython_directives['profile'] = True
 
-        if os.getenv('THRIFTRW_COVERAGE'):
-            # Add line tracing hooks to the generated C code. The hooks aren't
-            # actually enabled unless the CYTHON_TRACE macre is also set. This
-            # affects performance negatively and should only be used during
-            # testing.
-            extension_extras['define_macros'] = [('CYTHON_TRACE', '1')]
-            cython_directives['linetrace'] = True
+    if os.getenv('THRIFTRW_COVERAGE'):
+        # Add line tracing hooks to the generated C code. The hooks aren't
+        # actually enabled unless the CYTHON_TRACE macre is also set. This
+        # affects performance negatively and should only be used during
+        # testing.
+        extension_extras['define_macros'] = [('CYTHON_TRACE', '1')]
+        cython_directives['linetrace'] = True
 
-        if cython_directives:
-            extension_extras['cython_directives'] = cython_directives
+    if cython_directives:
+        extension_extras['cython_directives'] = cython_directives
 except ImportError:
     pass
 
@@ -118,6 +116,7 @@ class sdist(_sdist):
         except ImportError:
             pass
         _sdist.run(self)
+
 
 cmdclass['sdist'] = sdist
 

--- a/tests/protocol/test_binary.py
+++ b/tests/protocol/test_binary.py
@@ -180,11 +180,11 @@ def reader_writer_ids(x):
         0x68, 0x65, 0x6c, 0x6c, 0x6f,   # 'h', 'e', 'l', 'l', 'o'
     ], sbin, vbinary(b'hello')),
 
-    # struct = (type:1 id:2 value)* stop
+    # struct = (ttype:1 id:2 value)* stop
     # stop = 0
     (ttype.STRUCT, [0x00], sstruct(''), vstruct()),
     (ttype.STRUCT, [
-        0x02,        # type:1 = bool
+        0x02,        # ttype:1 = bool
         0x00, 0x01,  # id:2 = 1
         0x01,        # value = true
         0x00,        # stop
@@ -192,15 +192,15 @@ def reader_writer_ids(x):
      sstruct("1: optional bool param"),
      vstruct((1, ttype.BOOL, vbool(True)))),
     (ttype.STRUCT, [
-        0x06,           # type:1 = i16
+        0x06,           # ttype:1 = i16
         0x00, 0x01,     # id:2 = 1
         0x00, 0x2a,     # value = 42
 
-        0x0F,           # type:1 = list
+        0x0F,           # ttype:1 = list
         0x00, 0x02,     # id:2 = 2
 
         # <list>
-        0x0B,                       # type:1 = binary
+        0x0B,                       # ttype:1 = binary
         0x00, 0x00, 0x00, 0x02,     # size:4 = 2
         # <binary>
         0x00, 0x00, 0x00, 0x03,     # len:4 = 3
@@ -231,11 +231,11 @@ def reader_writer_ids(x):
         0x00, 0x00, 0x00, 0x02,     # count:4 = 2
 
         # <struct>
-        0x06,        # type:1 = i16
+        0x06,        # ttype:1 = i16
         0x00, 0x01,  # id:2 = 1
         0x00, 0x01,  # value = 1
 
-        0x08,                    # type:1 = i32
+        0x08,                    # ttype:1 = i32
         0x00, 0x02,              # id:2 = 2
         0x00, 0x00, 0x00, 0x02,  # value = 2
 
@@ -243,11 +243,11 @@ def reader_writer_ids(x):
         # </struct>
 
         # <struct>
-        0x06,        # type:1 = i16
+        0x06,        # ttype:1 = i16
         0x00, 0x01,  # id:2 = 1
         0x00, 0x03,  # value = 3
 
-        0x08,                    # type:1 = i32
+        0x08,                    # ttype:1 = i32
         0x00, 0x02,              # id:2 = 2
         0x00, 0x00, 0x00, 0x04,  # value = 4
 
@@ -358,7 +358,7 @@ def test_reader_and_writer_noorder(spec, value):
         ttype.STRUCT,
         sstruct("1: optional bool foo"),
         [
-            0x02,  # type:1 = bool
+            0x02,  # ttype:1 = bool
             # missing field ID
         ],
     ),
@@ -366,7 +366,7 @@ def test_reader_and_writer_noorder(spec, value):
         ttype.STRUCT,
         sstruct("1: optional bool foo"),
         [
-            0x02,  # type:1 = bool
+            0x02,  # ttype:1 = bool
             0x00,  # field ID too short
         ],
     ),
@@ -374,7 +374,7 @@ def test_reader_and_writer_noorder(spec, value):
         ttype.STRUCT,
         sstruct("1: optional bool foo"),
         [
-            0x02,        # type:1 = bool
+            0x02,        # ttype:1 = bool
             0x00, 0x01,  # id:2 = 1
             # Missing value
         ],
@@ -383,7 +383,7 @@ def test_reader_and_writer_noorder(spec, value):
         ttype.STRUCT,
         sstruct("1: optional i16 foo"),
         [
-            0x06,        # type:1 = i16
+            0x06,        # ttype:1 = i16
             0x00, 0x01,  # id:2 = 1
             0x00, 0x00,  # missing part of the value
         ],
@@ -392,7 +392,7 @@ def test_reader_and_writer_noorder(spec, value):
         ttype.STRUCT,
         sstruct("1: optional bool foo"),
         [
-            0x02,        # type:1 = bool
+            0x02,        # ttype:1 = bool
             0x00, 0x01,  # id:2 = 1
             0x01,        # true
             # Missing struct close
@@ -451,7 +451,7 @@ def test_unknown_type_id(typ, bs):
         0x00, 0x00, 0x00, 0x06,                 # length = 6
         0x67, 0x65, 0x74, 0x46, 0x6f, 0x6f,     # 'getFoo'
 
-        0x01,                       # type = CALL
+        0x01,                       # ttype = CALL
         0x00, 0x00, 0x00, 0x2a,     # seqId = 42
 
         0x00,
@@ -465,7 +465,7 @@ def test_unknown_type_id(typ, bs):
         0x00, 0x00, 0x00, 0x06,                 # length = 6
         0x73, 0x65, 0x74, 0x42, 0x61, 0x72,     # 'setBar'
 
-        0x02,                       # type = REPLY
+        0x02,                       # ttype = REPLY
         0x00, 0x00, 0x00, 0x01,     # seqId = 1
 
         0x02, 0x00, 0x01, 0x01,     # {1: True}
@@ -491,7 +491,7 @@ def test_message_round_trip(bs, message):
 @pytest.mark.parametrize('bs, message', [
     ([
         0x80, 0x01,  # version = 1
-        0x00, 0x03,  # type = EXCEPTION
+        0x00, 0x03,  # ttype = EXCEPTION
 
         0x00, 0x00, 0x00, 0x06,                 # length = 6
         0x67, 0x65, 0x74, 0x46, 0x6f, 0x6f,     # 'getFoo'
@@ -508,7 +508,7 @@ def test_message_round_trip(bs, message):
     )),
     ([
         0x80, 0x01,  # version = 1
-        0x00, 0x04,  # type = ONEWAY
+        0x00, 0x04,  # ttype = ONEWAY
 
         0x00, 0x00, 0x00, 0x06,                 # length = 6
         0x73, 0x65, 0x74, 0x42, 0x61, 0x72,     # 'setBar'
@@ -534,7 +534,7 @@ def test_message_parse_strict(bs, message):
 @pytest.mark.parametrize('bs', [
     [
         0x80, 0x2a,  # version = 42
-        0x00, 0x01,  # type = CALL
+        0x00, 0x01,  # ttype = CALL
         0x00, 0x00, 0x00, 0x06,                 # length = 6
         0x67, 0x65, 0x74, 0x46, 0x6f, 0x6f,     # 'getFoo'
         0x00, 0x00, 0x00, 0x01,     # seqId = 1

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -50,7 +50,7 @@ Service = service.Service
     (b'write', 42, mtype.ONEWAY, Service.write.request(b'hello'), [
         0x00, 0x00, 0x00, 0x05,         # length:4 = 5
         0x77, 0x72, 0x69, 0x74, 0x65,   # 'write'
-        0x04,                           # type:1 = ONEWAY
+        0x04,                           # mtype:1 = ONEWAY
         0x00, 0x00, 0x00, 0x2a,         # seqid:4 = 42
 
         0x0B,                           # ttype:1 = BINARY


### PR DESCRIPTION
In setup.py, we verify that we are using at least Cython 0.17. This
check is causing failures if the version of Cython being used is a pre
or post-release (0.20.1post0, for example).

It's unclear why the check was there versus in the requirements.txt in
the first place. Further, the version of Cython is relevant only at
development and release time.  Since it's about 4 years later and Cython
is on release 0.28, it's pretty safe to assume that we won't run into
0.17 on machines we release ThriftRW from.

This change drops the check from the setup.py and transfers the
constraint to requirements.txt.

Additionally, comments in some tests had to be changed because newer
versions of flake8 treat them as type hints.