### PR TITLE
Remove support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 matrix:
   include:
-    - {python: 3.4, env: TOX_ENV=py34}
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
     # Need sudo here to actually get xenial.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,cover,flake8,docs
+envlist = py27,py35,py36,py37,cover,flake8,docs
 usedevelop = true
 
 [testenv]
@@ -7,7 +7,6 @@ commands =
     python setup.py clean --all build_ext --force --inplace
     py.test -svv tests
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
This removes support for python 3.4, which stopped getting full support in August 2017 and stopped getting security fixes in 2019-03.

Ref: https://en.wikipedia.org/wiki/History_of_Python