### PR TITLE
Remove custom travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ matrix:
   include:
     - {python: 3.5, env: TOX_ENV=py35}
     - {python: 3.6, env: TOX_ENV=py36}
-    # Need sudo here to actually get xenial.
-    # See https://github.com/travis-ci/travis-ci/issues/9815
-    - {python: 3.7, env: TOX_ENV=py37, dist: xenial, sudo: true}
-    - {python: 3.8, env: TOX_ENV=py38, dist: xenial, sudo: true}
+    - {python: 3.7, env: TOX_ENV=py37}
+    - {python: 3.8, env: TOX_ENV=py38}
     - {env: TOX_ENV=cover}
     - {env: TOX_ENV=flake8}
     - {env: TOX_ENV=docs}


### PR DESCRIPTION
When these travis CI configs were first written, Ubuntu Xenial (16.04) was still new and didn't by default contain python 3.7 and 3.8.  Now, these special configs aren't needed so they can be removed.