### PR TITLE
Re-support Python 2

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '2.7'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cython>=0.29.29
+six
 ply

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     url='https://github.com/thriftrw/thriftrw-python',
     packages=find_packages(exclude=('tests', 'tests.*')),
     license='MIT',
-    install_requires=['ply'],
+    install_requires=['six', 'ply'],
     tests_require=['pytest', 'mock'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/spec/test_hashable.py
+++ b/tests/spec/test_hashable.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
+import six
 
 
 @pytest.mark.parametrize('name, src, kwargs', [
@@ -98,6 +99,7 @@ def test_hash_inequality(loads, name, src, kwargs1, kwargs2):
     assert hash(obj1) != hash(obj2)
 
 
+@pytest.mark.skipif(six.PY2, reason="All Python 2 classes are hashable")
 @pytest.mark.parametrize('name, src, kwargs', [
     (
         'Foo', '''

--- a/tests/spec/test_struct.py
+++ b/tests/spec/test_struct.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 import pytest
+import six
 
 from thriftrw.errors import ThriftCompilerError
 from thriftrw.spec.struct import StructTypeSpec
@@ -321,7 +322,7 @@ def test_default_binary_value(loads):
         1: optional binary field = "";
     }''').Struct
 
-    assert isinstance(Struct().field, bytes)
+    assert isinstance(Struct().field, six.binary_type)
 
 
 def test_constructor_behavior(loads):

--- a/thriftrw/idl/lexer.py
+++ b/thriftrw/idl/lexer.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 
+import six
 from ply import lex
 
 from ..errors import ThriftParserError
@@ -73,7 +74,7 @@ class LexerSpec(object):
         'DUBCONSTANT',
         'LITERAL',
         'IDENTIFIER',
-    ) + tuple(map(str.upper, THRIFT_KEYWORDS))
+    ) + tuple(map(six.text_type.upper, THRIFT_KEYWORDS))
 
     t_ignore = ' \t\r'  # whitespace
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = 3.7,3.8,3.9,3.10,3.11,cover,flake8,docs
+envlist = 2.7,3.7,3.8,3.9,3.10,3.11,cover,flake8,docs
 usedevelop = true
 
 [testenv]
@@ -7,6 +7,7 @@ commands =
     python setup.py clean --all build_ext --force --inplace
     py.test -svv tests
 basepython =
+    2.7: python2.7
     3.7: python3.7
     3.8: python3.8
     3.9: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,16 @@ basepython =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
-deps = -rrequirements-test.txt
+deps =
+    2.7: py-cpuinfo==8.0.0
+    2.7: pytest==4.6.11
+    2.7: pytest-cov==2.12.1
+    2.7: pytest-benchmark==3.4.1
+    3.7: -rrequirements-test.txt
+    3.8: -rrequirements-test.txt
+    3.9: -rrequirements-test.txt
+    3.10: -rrequirements-test.txt
+    3.11: -rrequirements-test.txt
 
 [testenv:cover]
 basepython = python

--- a/tox.ini
+++ b/tox.ini
@@ -37,5 +37,6 @@ basepython = python
 changedir = docs
 deps =
     sphinx
+    six
     ply
 commands = make html


### PR DESCRIPTION
I'd prefer us keep python 2 support dropped but if we really need to, we can bring back python 2 support (with testing). 

Another PR would be needed to release this.  It should probably be v1.10.0 so that it's the same type of version bump as 1.9.0 which dropped python 2 support.